### PR TITLE
Handle empty string secrets

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type GKE struct {
 	Template       string                 `json:"template"`
 	SecretTemplate string                 `json:"secret_template"`
 	Vars           map[string]interface{} `json:"vars"`
-	Secrets        map[string]interface{} `json:"secrets"`
+	Secrets        map[string]string      `json:"secrets"`
 }
 
 var (
@@ -182,7 +182,7 @@ func wrapMain() error {
 	secrets := map[string]interface{}{}
 	for k, v := range vargs.Secrets {
 		// Base64 encode secret strings.
-		secrets[k] = base64.StdEncoding.EncodeToString([]byte(v.(string)))
+		secrets[k] = base64.StdEncoding.EncodeToString([]byte(v))
 	}
 
 	mapping := map[string]map[string]interface{}{

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type GKE struct {
 	Template       string                 `json:"template"`
 	SecretTemplate string                 `json:"secret_template"`
 	Vars           map[string]interface{} `json:"vars"`
-	Secrets        map[string]string      `json:"secrets"`
+	Secrets        map[string]interface{} `json:"secrets"`
 }
 
 var (
@@ -181,8 +181,12 @@ func wrapMain() error {
 
 	secrets := map[string]interface{}{}
 	for k, v := range vargs.Secrets {
+		if v == nil {
+			return fmt.Errorf("Error: secret var %q is nil (empty string)\n", k)
+		}
+
 		// Base64 encode secret strings.
-		secrets[k] = base64.StdEncoding.EncodeToString([]byte(v))
+		secrets[k] = base64.StdEncoding.EncodeToString([]byte(v.(string)))
 	}
 
 	mapping := map[string]map[string]interface{}{

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type GKE struct {
 	Template       string                 `json:"template"`
 	SecretTemplate string                 `json:"secret_template"`
 	Vars           map[string]interface{} `json:"vars"`
-	Secrets        map[string]interface{} `json:"secrets"`
+	Secrets        map[string]string      `json:"secrets"`
 }
 
 var (
@@ -181,12 +181,12 @@ func wrapMain() error {
 
 	secrets := map[string]interface{}{}
 	for k, v := range vargs.Secrets {
-		if v == nil {
-			return fmt.Errorf("Error: secret var %q is nil (empty string)\n", k)
+		if v == "" {
+			return fmt.Errorf("Error: secret var %q is an empty string\n", k)
 		}
 
 		// Base64 encode secret strings.
-		secrets[k] = base64.StdEncoding.EncodeToString([]byte(v.(string)))
+		secrets[k] = base64.StdEncoding.EncodeToString([]byte(v))
 	}
 
 	mapping := map[string]map[string]interface{}{


### PR DESCRIPTION
Show an explicit error when a secret variable was set as an empty string.

Alternative could be to silently ignore it (c44177f), but I can see that breaking deployments, and so I'd rather catch the problem earlier, during the templating process of Kubernetes configs.

Closes #17.