### PR TITLE
Update gcloud to 141.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV GOOGLE_CLOUD_SDK_VERSION=135.0.0
+ENV GOOGLE_CLOUD_SDK_VERSION=141.0.0
 
 RUN apk add --no-cache curl python
 


### PR DESCRIPTION
This updates `gcloud` version to `141.0.0` for `kubectl 1.5.2`.