### PR TITLE
Post kubectl apply commands

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -18,6 +18,8 @@ The following parameters are used to configure this plugin:
 * `vars` - variables to use in `template`
 * `secrets` - variables to use in `secret_template`. These are base64 encoded by the plugin.
 * `secrets_base64` - variables to use in `secret_template`. These should already be base64 encoded; the plugin will not do so.
+* `pre` - commands to run before applying the Kubernetes files
+* `post` - commands to run after applying the Kubernetes files
 
 Optional (useful for debugging):
 
@@ -78,6 +80,11 @@ deploy:
       api_token: $$API_TOKEN
     secrets_base64:
       p12_cert: $$P12_CERT
+
+    pre:
+      - kubectl get pods
+    post:
+      - kubectl get pods
 
     when:
       event: push

--- a/DOCS.md
+++ b/DOCS.md
@@ -18,7 +18,7 @@ The following parameters are used to configure this plugin:
 * `vars` - variables to use in `template`
 * `secrets` - variables to use in `secret_template`. These are base64 encoded by the plugin.
 * `secrets_base64` - variables to use in `secret_template`. These should already be base64 encoded; the plugin will not do so.
-* `post` - commands to run after applying the Kubernetes files
+* `post_cmds` - commands to run after applying the Kubernetes files
 
 Optional (useful for debugging):
 
@@ -80,7 +80,7 @@ deploy:
     secrets_base64:
       p12_cert: $$P12_CERT
 
-    post:
+    post_cmds:
       - kubectl get pods
 
     when:

--- a/DOCS.md
+++ b/DOCS.md
@@ -18,7 +18,6 @@ The following parameters are used to configure this plugin:
 * `vars` - variables to use in `template`
 * `secrets` - variables to use in `secret_template`. These are base64 encoded by the plugin.
 * `secrets_base64` - variables to use in `secret_template`. These should already be base64 encoded; the plugin will not do so.
-* `pre` - commands to run before applying the Kubernetes files
 * `post` - commands to run after applying the Kubernetes files
 
 Optional (useful for debugging):
@@ -81,8 +80,6 @@ deploy:
     secrets_base64:
       p12_cert: $$P12_CERT
 
-    pre:
-      - kubectl get pods
     post:
       - kubectl get pods
 

--- a/exec.go
+++ b/exec.go
@@ -32,7 +32,6 @@ func (e *Environ) Run(name string, arg ...string) error {
 	cmd.Stderr = e.stderr
 
 	// TODO: Extract this
-	fmt.Println()
 	fmt.Println("$", strings.Join(cmd.Args, " "))
 	//--
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ type GKE struct {
 	// thus don't need to be re-encoded as they would be if they were in
 	// the Secrets field.
 	SecretsBase64 map[string]string `json:"secrets_base64"`
-	Pre           []string          `json:"pre"`
 	Post          []string          `json:"post"`
 }
 
@@ -292,16 +291,6 @@ func wrapMain() error {
 
 		// Ensure the namespace exists, without errors (unlike `kubectl create namespace`).
 		err = runner.Run(vargs.KubectlCmd, "apply", "--filename", nsPath)
-		if err != nil {
-			return fmt.Errorf("Error: %s\n", err)
-		}
-	}
-
-	// Pre
-	for _, v := range vargs.Pre {
-		cmds := strings.Split(v, " ")
-
-		err = runner.Run(cmds[0], cmds[1:]...)
 		if err != nil {
 			return fmt.Errorf("Error: %s\n", err)
 		}

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ type GKE struct {
 	// thus don't need to be re-encoded as they would be if they were in
 	// the Secrets field.
 	SecretsBase64 map[string]string `json:"secrets_base64"`
-	Post          []string          `json:"post"`
+	PostCmds      []string          `json:"post_cmds"`
 }
 
 var (
@@ -302,8 +302,8 @@ func wrapMain() error {
 		return fmt.Errorf("Error: %s\n", err)
 	}
 
-	// Post
-	for _, v := range vargs.Post {
+	// Post commands
+	for _, v := range vargs.PostCmds {
 		cmds := strings.Split(v, " ")
 
 		err = runner.Run(cmds[0], cmds[1:]...)


### PR DESCRIPTION
Follow up to #11.

Allow the user to run commands after `kubectl apply -f ...` to do followup tasks after deployment.

Use cases:
- Run perf / canary tests that can't be triggered via webhooks
- Copy `/tmp/.kube.yml files` to `/drone/*` for uploading with the S3/GCS plugins
- Run `kubectl get ...` to show statuses of resources post deployment