### PR TITLE
update interface for drone v0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV GOOGLE_CLOUD_SDK_VERSION=158.0.0
+ENV GOOGLE_CLOUD_SDK_VERSION=141.0.0
 
 RUN apk add --no-cache curl python
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV GOOGLE_CLOUD_SDK_VERSION=141.0.0
+ENV GOOGLE_CLOUD_SDK_VERSION=158.0.0
 
 RUN apk add --no-cache curl python
 

--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func wrapMain() error {
 
 func run(c *cli.Context) error {
 	vargs := GKE{}
-	vargs.DryRun = c.Bool("token")
+	vargs.DryRun = c.Bool("dry-run")
 	vargs.Verbose = c.Bool("verbose")
 	vargs.Token = c.String("token")
 	vargs.GCloudCmd = c.String("gcloud-cmd")


### PR DESCRIPTION
This represents what I think is a simple and clear change to port this plugin to drone v0.5+. It adds a `urfave/cli` interface to accept env vars, and then has a simple compatability/adapter section that re-assigns input from the new interface to the old data structure, `type GKE`. 

Once it is tested, the parts still using the v0.4 style interface can be cleaned up.

This is how the cleanup looks: https://github.com/stephansnyt/drone-gke/compare/feature/drone-0.6...stephansnyt:feature/remove-drone-0.4-code?expand=1

Also this PR does not correctly update handling of secrets. A possible solution is implemented here: https://github.com/stephansnyt/drone-gke/compare/feature/remove-drone-0.4-code...stephansnyt:secretmap?expand=1