### PR TITLE
Set missing env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN ./google-cloud-sdk/install.sh --quiet
 # Install kubectl
 RUN ./google-cloud-sdk/bin/gcloud components install kubectl
 
+ENV CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
+
 # Clean up
 RUN rm -rf ./google-cloud-sdk/.install
 


### PR DESCRIPTION
Fix the error from newer version of `gcloud`:
```
$ export CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
ERROR: (gcloud.container.clusters.get-credentials) Path to sdk installation not found. Please switch to application default credentials using one of
```