### PR TITLE
Fix spacing issues when dumping info

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -8,7 +8,7 @@ import (
 )
 
 func dumpData(w io.Writer, caption string, data interface{}) {
-	fmt.Fprintf(w, "---START %s---\n", caption)
+	fmt.Fprintf(w, "\n---START %s---\n", caption)
 	defer fmt.Fprintf(w, "---END %s---\n", caption)
 
 	b, err := json.MarshalIndent(data, "", "\t")
@@ -22,7 +22,7 @@ func dumpData(w io.Writer, caption string, data interface{}) {
 }
 
 func dumpFile(w io.Writer, caption, path string) {
-	fmt.Fprintf(w, "---START %s---\n", caption)
+	fmt.Fprintf(w, "\n---START %s---\n", caption)
 	defer fmt.Fprintf(w, "---END %s---\n", caption)
 
 	data, err := ioutil.ReadFile(path)


### PR DESCRIPTION
This will clearly delineate between the blocks of verbosely printed content.

![screen shot 2017-08-11 at 2 12 54 pm](https://user-images.githubusercontent.com/3250776/29226303-83228f50-7e9f-11e7-95f5-dd9c50da7dc5.png)
