### PR TITLE
Clean up plugin implementation updates

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
-hash: 702072e4a47e18b7d0660fc1c1af8200a39ef136d72248683cd835ce98736f3f
-updated: 2016-09-02T16:47:33.089645995-04:00
+hash: b36e98a39d5f3653dfa1c180057c8b5bff181d242b63659f54eb23dec055197c
+updated: 2017-08-09T14:48:49.893040171-04:00
 imports:
 - name: github.com/drone/drone-plugin-go
   version: d6109f644c5935c22620081b4c234bb2263743c7
   subpackages:
   - plugin
+- name: github.com/urfave/cli
+  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
 testImports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,3 +3,5 @@ import:
 - package: github.com/drone/drone-plugin-go
   subpackages:
   - plugin
+- package: github.com/urfave/cli
+  version: ^1.19.1

--- a/main.go
+++ b/main.go
@@ -405,8 +405,24 @@ func run(c *cli.Context) error {
 		}
 	}
 
-	// Apply Kubernetes manifests.
-	args := applyArgs(c.Bool("dry-run"), strings.Join(pathArg, ","))
+	manifests := strings.Join(pathArg, ",")
+
+	// If it is not a dry run, do a dry run first to validate Kubernetes manifests.
+	log("Validating Kubernetes manifests with a dry-run\n")
+
+	if !c.Bool("dry-run") {
+		args := applyArgs(true, manifests)
+		err = runner.Run(kubectlCmd, args...)
+		if err != nil {
+			return fmt.Errorf("Error: %s\n", err)
+		}
+
+		log("Applying Kubernetes manifests to the cluster\n")
+	}
+
+	// Actually apply Kubernetes manifests.
+
+	args := applyArgs(c.Bool("dry-run"), manifests)
 	err = runner.Run(kubectlCmd, args...)
 	if err != nil {
 		return fmt.Errorf("Error: %s\n", err)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 )
 
 var (
+	// Build revision is set at compile time.
 	rev string
 )
 
@@ -158,7 +159,7 @@ func run(c *cli.Context) error {
 	sdkPath := "/google-cloud-sdk"
 	keyPath := "/tmp/gcloud.json"
 
-	// Defaults.
+	// Set defaults.
 	gcloudCmd := c.String("gcloud-cmd")
 	if gcloudCmd == "" {
 		gcloudCmd = fmt.Sprintf("%s/bin/gcloud", sdkPath)
@@ -195,10 +196,10 @@ func run(c *cli.Context) error {
 			continue
 		}
 
-		// Only split up to 2 parts
+		// Only split up to 2 parts.
 		pair := strings.SplitN(e, "=", 2)
 
-		// Check that key and value both exist
+		// Check that key and value both exist.
 		if len(pair) != 2 {
 			return fmt.Errorf("Error: secret key and value mismatch, expected 2, got %d", len(pair))
 		}
@@ -284,6 +285,7 @@ func run(c *cli.Context) error {
 
 	secretsAndData := map[string]interface{}{}
 
+	// Add variables to data used for rendering both templates.
 	for k, v := range vars {
 		// Don't allow vars to be overridden.
 		// We do this to ensure that the built-in template vars (above) can be relied upon.
@@ -339,12 +341,13 @@ func run(c *cli.Context) error {
 			}
 		}
 
-		// Generate the file.
+		// Read the template.
 		blob, err := ioutil.ReadFile(inPath)
 		if err != nil {
 			return fmt.Errorf("Error reading template: %s\n", err)
 		}
 
+		// Parse the template.
 		tmpl, err := template.New(bn).Option("missingkey=error").Parse(string(blob))
 		if err != nil {
 			return fmt.Errorf("Error parsing template: %s\n", err)
@@ -363,6 +366,7 @@ func run(c *cli.Context) error {
 
 		f.Close()
 
+		// Add the manifest filepath to the list of manifests to apply.
 		pathArg = append(pathArg, outPaths[t])
 	}
 
@@ -385,6 +389,7 @@ func run(c *cli.Context) error {
 	if len(c.String("namespace")) > 0 {
 		fmt.Printf("Configuring kubectl to the %s namespace\n", c.String("namespace"))
 
+		// Set the execution namespace.
 		context := strings.Join([]string{"gke", project, c.String("zone"), c.String("cluster")}, "_")
 
 		err = runner.Run(kubectlCmd, "config", "set-context", context, "--namespace", c.String("namespace"))

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ const (
 	kubectlCmd = "kubectl"
 
 	keyPath = "/tmp/gcloud.json"
+	nsPath  = "/tmp/namespace.json"
 )
 
 var nsTemplate = `
@@ -375,7 +376,6 @@ func run(c *cli.Context) error {
 		}
 
 		// Write the namespace manifest to a tmp file for application.
-		nsPath := "/tmp/namespace.json"
 		resource := fmt.Sprintf(nsTemplate, namespace)
 
 		err := ioutil.WriteFile(nsPath, []byte(resource), 0600)

--- a/main.go
+++ b/main.go
@@ -147,9 +147,13 @@ func run(c *cli.Context) error {
 		return fmt.Errorf("Missing required param: token")
 	}
 
-	project := getProjectFromToken(token)
+	// Use project if explicitly stated, otherwise infer from the service account token.
+	project := c.String("project")
 	if project == "" {
-		return fmt.Errorf("Missing required param: project")
+		project = getProjectFromToken(token)
+		if project == "" {
+			return fmt.Errorf("Missing required param: project")
+		}
 	}
 
 	if c.String("zone") == "" {

--- a/main.go
+++ b/main.go
@@ -439,7 +439,6 @@ func applyArgs(dryrun bool, file string) []string {
 	return args
 }
 
-func log(format string, a ...interface{}) (int, error) {
-	fmt.Println()
-	return fmt.Printf(format, a...)
+func log(format string, a ...interface{}) {
+	fmt.Printf("\n"+format, a...)
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ var (
 const (
 	gcloudCmd  = "gcloud"
 	kubectlCmd = "kubectl"
+
+	keyPath = "/tmp/gcloud.json"
 )
 
 var nsTemplate = `
@@ -155,8 +157,6 @@ func run(c *cli.Context) error {
 		return fmt.Errorf("Missing required param: zone")
 	}
 
-	keyPath := "/tmp/gcloud.json"
-
 	// Enforce default values.
 	kubeTemplate := c.String("kube-template")
 	if kubeTemplate == "" {
@@ -222,12 +222,12 @@ func run(c *cli.Context) error {
 
 	// Warn if the keyfile can't be deleted, but don't abort.
 	// We're almost certainly running inside an ephemeral container, so the file will be discarded when we're finished anyway.
-	defer func(keyPath string) {
+	defer func() {
 		err := os.Remove(keyPath)
 		if err != nil {
 			log("Warning: error removing token file: %s\n", err)
 		}
-	}(keyPath)
+	}()
 
 	// Set up the execution environment.
 	wd, err := os.Getwd()

--- a/main.go
+++ b/main.go
@@ -374,20 +374,21 @@ func run(c *cli.Context) error {
 		return fmt.Errorf("Error: %s\n", err)
 	}
 
-	if len(c.String("namespace")) > 0 {
-		fmt.Printf("\nConfiguring kubectl to the '%s' namespace\n", c.String("namespace"))
+	namespace := c.String("namespace")
 
+	if len(namespace) > 0 {
 		// Set the execution namespace.
-		context := strings.Join([]string{"gke", project, c.String("zone"), c.String("cluster")}, "_")
+		log("Configuring kubectl to the %s namespace\n", namespace)
 
-		err = runner.Run(kubectlCmd, "config", "set-context", context, "--namespace", c.String("namespace"))
+		context := strings.Join([]string{"gke", project, c.String("zone"), c.String("cluster")}, "_")
+		err = runner.Run(kubectlCmd, "config", "set-context", context, "--namespace", namespace)
 		if err != nil {
 			return fmt.Errorf("Error: %s\n", err)
 		}
 
 		// Write the namespace manifest to a tmp file for application.
 		nsPath := "/tmp/namespace.json"
-		resource := fmt.Sprintf(nsTemplate, c.String("namespace"))
+		resource := fmt.Sprintf(nsTemplate, namespace)
 
 		err := ioutil.WriteFile(nsPath, []byte(resource), 0600)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -354,6 +354,12 @@ func run(c *cli.Context) error {
 		return nil
 	}
 
+	// Print kubectl version.
+	err = runner.Run(kubectlCmd, "version")
+	if err != nil {
+		return fmt.Errorf("Error: %s\n", err)
+	}
+
 	// Set the execution namespace.
 	if len(c.String("namespace")) > 0 {
 		fmt.Printf("Configuring kubectl to the %s namespace\n", c.String("namespace"))

--- a/main.go
+++ b/main.go
@@ -268,13 +268,6 @@ func run(c *cli.Context) error {
 		"BRANCH":       c.String("drone-branch"),
 		"TAG":          c.String("drone-tag"),
 
-		// https://godoc.org/github.com/drone/drone-plugin-go/plugin#Workspace
-		// TODO do we really need these?
-		// "workspace": workspace,
-		// "repo":      repo,
-		// "build":     build,
-		// "system":    system,
-
 		// Misc useful stuff.
 		// Note that secrets (including the GCP token) are excluded
 		"project":   project,

--- a/main.go
+++ b/main.go
@@ -356,7 +356,7 @@ func run(c *cli.Context) error {
 
 	namespace := c.String("namespace")
 
-	if len(namespace) > 0 {
+	if namespace != "" {
 		// Set the execution namespace.
 		log("Configuring kubectl to the %s namespace\n", namespace)
 

--- a/main.go
+++ b/main.go
@@ -18,6 +18,11 @@ var (
 	rev string
 )
 
+const (
+	gcloudCmd  = "gcloud"
+	kubectlCmd = "kubectl"
+)
+
 var nsTemplate = `
 ---
 apiVersion: v1
@@ -61,16 +66,6 @@ func wrapMain() error {
 			Name:   "token",
 			Usage:  "service account's JSON credentials",
 			EnvVar: "TOKEN",
-		},
-		cli.StringFlag{
-			Name:   "gcloud-cmd",
-			Usage:  "alternative gcloud cmd",
-			EnvVar: "PLUGIN_GCLOUD_CMD",
-		},
-		cli.StringFlag{
-			Name:   "kubectl-cmd",
-			Usage:  "alternative kubectl cmd",
-			EnvVar: "PLUGIN_KUBECTL_CMD",
 		},
 		cli.StringFlag{
 			Name:   "project",
@@ -160,20 +155,9 @@ func run(c *cli.Context) error {
 		return fmt.Errorf("Missing required param: zone")
 	}
 
-	sdkPath := "/google-cloud-sdk"
 	keyPath := "/tmp/gcloud.json"
 
-	// Set defaults.
-	gcloudCmd := c.String("gcloud-cmd")
-	if gcloudCmd == "" {
-		gcloudCmd = fmt.Sprintf("%s/bin/gcloud", sdkPath)
-	}
-
-	kubectlCmd := c.String("kubectl-cmd")
-	if kubectlCmd == "" {
-		kubectlCmd = fmt.Sprintf("%s/bin/kubectl", sdkPath)
-	}
-
+	// Enforce default values.
 	kubeTemplate := c.String("kube-template")
 	if kubeTemplate == "" {
 		kubeTemplate = ".kube.yml"

--- a/main.go
+++ b/main.go
@@ -48,12 +48,12 @@ func wrapMain() error {
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:   "dry-run",
-			Usage:  "do not apply the Kubernetes templates",
+			Usage:  "do not apply the Kubernetes manifests to the API server",
 			EnvVar: "PLUGIN_DRY_RUN",
 		},
 		cli.BoolFlag{
 			Name:   "verbose",
-			Usage:  "dry run disables docker push",
+			Usage:  "dump available vars and the generated Kubernetes manifest, keeping secrets hidden",
 			EnvVar: "PLUGIN_VERBOSE",
 		},
 		cli.StringFlag{
@@ -73,7 +73,7 @@ func wrapMain() error {
 		},
 		cli.StringFlag{
 			Name:   "project",
-			Usage:  "gcp project",
+			Usage:  "GCP project name",
 			EnvVar: "PLUGIN_PROJECT",
 		},
 		cli.StringFlag{
@@ -89,43 +89,43 @@ func wrapMain() error {
 		cli.StringFlag{
 			Name:   "namespace",
 			Usage:  "Kubernetes namespace to operate in",
-			EnvVar: "PLUGIN_NAMEPSACE",
+			EnvVar: "PLUGIN_NAMESPACE",
 		},
 		cli.StringFlag{
 			Name:   "kube-template",
-			Usage:  "optional - template for e.g. deployments",
+			Usage:  "optional - template for Kubernetes resources, e.g. deployments",
 			EnvVar: "PLUGIN_TEMPLATE",
 			Value:  ".kube.yml",
 		},
 		cli.StringFlag{
 			Name:   "secret-template",
-			Usage:  "optional - template for the secret object",
+			Usage:  "optional - template for Kubernetes Secret resources",
 			EnvVar: "PLUGIN_SECRET_TEMPLATE",
 			Value:  ".kube.sec.yml",
 		},
 		cli.StringFlag{
 			Name:   "vars",
-			Usage:  "variables to use in template",
+			Usage:  "variables to use while templating manifests",
 			EnvVar: "PLUGIN_VARS",
 		},
 		cli.StringFlag{
 			Name:   "drone-build-number",
-			Usage:  "variables to use in secret_template. These should already be base64 encoded; the plugin will not do so.",
+			Usage:  "Drone build number",
 			EnvVar: "DRONE_BUILD_NUMBER",
 		},
 		cli.StringFlag{
 			Name:   "drone-commit",
-			Usage:  "variables to use in secret_template. These should already be base64 encoded; the plugin will not do so.",
+			Usage:  "Git commit hash",
 			EnvVar: "DRONE_COMMIT",
 		},
 		cli.StringFlag{
 			Name:   "drone-branch",
-			Usage:  "variables to use in secret_template. These should already be base64 encoded; the plugin will not do so.",
+			Usage:  "Git branch",
 			EnvVar: "DRONE_BRANCH",
 		},
 		cli.StringFlag{
 			Name:   "drone-tag",
-			Usage:  "variables to use in secret_template. These should already be base64 encoded; the plugin will not do so.",
+			Usage:  "Git tag",
 			EnvVar: "DRONE_TAG",
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -237,7 +237,7 @@ func run(c *cli.Context) error {
 	defer func(keyPath string) {
 		err := os.Remove(keyPath)
 		if err != nil {
-			fmt.Printf("Warning: error removing token file: %s\n", err)
+			log("Warning: error removing token file: %s\n", err)
 		}
 	}(keyPath)
 
@@ -329,7 +329,7 @@ func run(c *cli.Context) error {
 				return fmt.Errorf("Error finding template: %s\n", err)
 			}
 
-			fmt.Printf("Warning: skipping optional template %s, it was not found\n", t)
+			log("Warning: skipping optional template %s because it was not found\n", t)
 			continue
 		}
 
@@ -395,6 +395,8 @@ func run(c *cli.Context) error {
 		}
 
 		// Ensure the namespace exists, without errors (unlike `kubectl create namespace`).
+		log("Ensuring the %s namespace exists\n", namespace)
+
 		nsArgs := applyArgs(c.Bool("dry-run"), nsPath)
 		err = runner.Run(kubectlCmd, nsArgs...)
 		if err != nil {
@@ -439,4 +441,9 @@ func applyArgs(dryrun bool, file string) []string {
 	args = append(args, file)
 
 	return args
+}
+
+func log(format string, a ...interface{}) (int, error) {
+	fmt.Println()
+	return fmt.Printf(format, a...)
 }

--- a/main.go
+++ b/main.go
@@ -182,9 +182,9 @@ func run(c *cli.Context) error {
 
 	// Parse variables.
 	vars := make(map[string]interface{})
-	varsJson := c.String("vars")
-	if varsJson != "" {
-		if err := json.Unmarshal([]byte(varsJson), &vars); err != nil {
+	varsJSON := c.String("vars")
+	if varsJSON != "" {
+		if err := json.Unmarshal([]byte(varsJSON), &vars); err != nil {
 			return fmt.Errorf("Error parsing vars: %s\n", err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -234,12 +234,12 @@ func run(c *cli.Context) error {
 
 	// Warn if the keyfile can't be deleted, but don't abort.
 	// We're almost certainly running inside an ephemeral container, so the file will be discarded when we're finished anyway.
-	defer func() {
+	defer func(keyPath string) {
 		err := os.Remove(keyPath)
 		if err != nil {
 			fmt.Printf("Warning: error removing token file: %s\n", err)
 		}
-	}()
+	}(keyPath)
 
 	// Set up the execution environment.
 	wd, err := os.Getwd()

--- a/vendor/github.com/urfave/cli/.gitignore
+++ b/vendor/github.com/urfave/cli/.gitignore
@@ -1,0 +1,2 @@
+*.coverprofile
+node_modules/

--- a/vendor/github.com/urfave/cli/.travis.yml
+++ b/vendor/github.com/urfave/cli/.travis.yml
@@ -1,0 +1,39 @@
+language: go
+
+sudo: false
+
+cache:
+  directories:
+  - node_modules
+
+go:
+- 1.2.x
+- 1.3.x
+- 1.4.2
+- 1.5.x
+- 1.6.x
+- 1.7.x
+- master
+
+matrix:
+  allow_failures:
+  - go: master
+  include:
+  - go: 1.6.x
+    os: osx
+  - go: 1.7.x
+    os: osx
+
+before_script:
+- go get github.com/urfave/gfmrun/... || true
+- go get golang.org/x/tools/... || true
+- if [ ! -f node_modules/.bin/markdown-toc ] ; then
+    npm install markdown-toc ;
+  fi
+
+script:
+- ./runtests gen
+- ./runtests vet
+- ./runtests test
+- ./runtests gfmrun
+- ./runtests toc

--- a/vendor/github.com/urfave/cli/CHANGELOG.md
+++ b/vendor/github.com/urfave/cli/CHANGELOG.md
@@ -1,0 +1,392 @@
+# Change Log
+
+**ATTN**: This project uses [semantic versioning](http://semver.org/).
+
+## [Unreleased]
+
+## [1.19.1] - 2016-11-21
+
+### Fixed
+
+- Fixes regression introduced in 1.19.0 where using an `ActionFunc` as
+  the `Action` for a command would cause it to error rather than calling the
+  function. Should not have a affected declarative cases using `func(c
+  *cli.Context) err)`.
+- Shell completion now handles the case where the user specifies
+  `--generate-bash-completion` immediately after a flag that takes an argument.
+  Previously it call the application with `--generate-bash-completion` as the
+  flag value.
+
+## [1.19.0] - 2016-11-19
+### Added
+- `FlagsByName` was added to make it easy to sort flags (e.g. `sort.Sort(cli.FlagsByName(app.Flags))`)
+- A `Description` field was added to `App` for a more detailed description of
+  the application (similar to the existing `Description` field on `Command`)
+- Flag type code generation via `go generate`
+- Write to stderr and exit 1 if action returns non-nil error
+- Added support for TOML to the `altsrc` loader
+- `SkipArgReorder` was added to allow users to skip the argument reordering.
+  This is useful if you want to consider all "flags" after an argument as
+  arguments rather than flags (the default behavior of the stdlib `flag`
+  library). This is backported functionality from the [removal of the flag
+  reordering](https://github.com/urfave/cli/pull/398) in the unreleased version
+  2
+- For formatted errors (those implementing `ErrorFormatter`), the errors will
+  be formatted during output. Compatible with `pkg/errors`.
+
+### Changed
+- Raise minimum tested/supported Go version to 1.2+
+
+### Fixed
+- Consider empty environment variables as set (previously environment variables
+  with the equivalent of `""` would be skipped rather than their value used).
+- Return an error if the value in a given environment variable cannot be parsed
+  as the flag type. Previously these errors were silently swallowed.
+- Print full error when an invalid flag is specified (which includes the invalid flag)
+- `App.Writer` defaults to `stdout` when `nil`
+- If no action is specified on a command or app, the help is now printed instead of `panic`ing
+- `App.Metadata` is initialized automatically now (previously was `nil` unless initialized)
+- Correctly show help message if `-h` is provided to a subcommand
+- `context.(Global)IsSet` now respects environment variables. Previously it
+  would return `false` if a flag was specified in the environment rather than
+  as an argument
+- Removed deprecation warnings to STDERR to avoid them leaking to the end-user
+- `altsrc`s import paths were updated to use `gopkg.in/urfave/cli.v1`. This
+  fixes issues that occurred when `gopkg.in/urfave/cli.v1` was imported as well
+  as `altsrc` where Go would complain that the types didn't match
+
+## [1.18.1] - 2016-08-28
+### Fixed
+- Removed deprecation warnings to STDERR to avoid them leaking to the end-user (backported)
+
+## [1.18.0] - 2016-06-27
+### Added
+- `./runtests` test runner with coverage tracking by default
+- testing on OS X
+- testing on Windows
+- `UintFlag`, `Uint64Flag`, and `Int64Flag` types and supporting code
+
+### Changed
+- Use spaces for alignment in help/usage output instead of tabs, making the
+  output alignment consistent regardless of tab width
+
+### Fixed
+- Printing of command aliases in help text
+- Printing of visible flags for both struct and struct pointer flags
+- Display the `help` subcommand when using `CommandCategories`
+- No longer swallows `panic`s that occur within the `Action`s themselves when
+  detecting the signature of the `Action` field
+
+## [1.17.1] - 2016-08-28
+### Fixed
+- Removed deprecation warnings to STDERR to avoid them leaking to the end-user
+
+## [1.17.0] - 2016-05-09
+### Added
+- Pluggable flag-level help text rendering via `cli.DefaultFlagStringFunc`
+- `context.GlobalBoolT` was added as an analogue to `context.GlobalBool`
+- Support for hiding commands by setting `Hidden: true` -- this will hide the
+  commands in help output
+
+### Changed
+- `Float64Flag`, `IntFlag`, and `DurationFlag` default values are no longer
+  quoted in help text output.
+- All flag types now include `(default: {value})` strings following usage when a
+  default value can be (reasonably) detected.
+- `IntSliceFlag` and `StringSliceFlag` usage strings are now more consistent
+  with non-slice flag types
+- Apps now exit with a code of 3 if an unknown subcommand is specified
+  (previously they printed "No help topic for...", but still exited 0. This
+  makes it easier to script around apps built using `cli` since they can trust
+  that a 0 exit code indicated a successful execution.
+- cleanups based on [Go Report Card
+  feedback](https://goreportcard.com/report/github.com/urfave/cli)
+
+## [1.16.1] - 2016-08-28
+### Fixed
+- Removed deprecation warnings to STDERR to avoid them leaking to the end-user
+
+## [1.16.0] - 2016-05-02
+### Added
+- `Hidden` field on all flag struct types to omit from generated help text
+
+### Changed
+- `BashCompletionFlag` (`--enable-bash-completion`) is now omitted from
+generated help text via the `Hidden` field
+
+### Fixed
+- handling of error values in `HandleAction` and `HandleExitCoder`
+
+## [1.15.0] - 2016-04-30
+### Added
+- This file!
+- Support for placeholders in flag usage strings
+- `App.Metadata` map for arbitrary data/state management
+- `Set` and `GlobalSet` methods on `*cli.Context` for altering values after
+parsing.
+- Support for nested lookup of dot-delimited keys in structures loaded from
+YAML.
+
+### Changed
+- The `App.Action` and `Command.Action` now prefer a return signature of
+`func(*cli.Context) error`, as defined by `cli.ActionFunc`.  If a non-nil
+`error` is returned, there may be two outcomes:
+    - If the error fulfills `cli.ExitCoder`, then `os.Exit` will be called
+    automatically
+    - Else the error is bubbled up and returned from `App.Run`
+- Specifying an `Action` with the legacy return signature of
+`func(*cli.Context)` will produce a deprecation message to stderr
+- Specifying an `Action` that is not a `func` type will produce a non-zero exit
+from `App.Run`
+- Specifying an `Action` func that has an invalid (input) signature will
+produce a non-zero exit from `App.Run`
+
+### Deprecated
+- <a name="deprecated-cli-app-runandexitonerror"></a>
+`cli.App.RunAndExitOnError`, which should now be done by returning an error
+that fulfills `cli.ExitCoder` to `cli.App.Run`.
+- <a name="deprecated-cli-app-action-signature"></a> the legacy signature for
+`cli.App.Action` of `func(*cli.Context)`, which should now have a return
+signature of `func(*cli.Context) error`, as defined by `cli.ActionFunc`.
+
+### Fixed
+- Added missing `*cli.Context.GlobalFloat64` method
+
+## [1.14.0] - 2016-04-03 (backfilled 2016-04-25)
+### Added
+- Codebeat badge
+- Support for categorization via `CategorizedHelp` and `Categories` on app.
+
+### Changed
+- Use `filepath.Base` instead of `path.Base` in `Name` and `HelpName`.
+
+### Fixed
+- Ensure version is not shown in help text when `HideVersion` set.
+
+## [1.13.0] - 2016-03-06 (backfilled 2016-04-25)
+### Added
+- YAML file input support.
+- `NArg` method on context.
+
+## [1.12.0] - 2016-02-17 (backfilled 2016-04-25)
+### Added
+- Custom usage error handling.
+- Custom text support in `USAGE` section of help output.
+- Improved help messages for empty strings.
+- AppVeyor CI configuration.
+
+### Changed
+- Removed `panic` from default help printer func.
+- De-duping and optimizations.
+
+### Fixed
+- Correctly handle `Before`/`After` at command level when no subcommands.
+- Case of literal `-` argument causing flag reordering.
+- Environment variable hints on Windows.
+- Docs updates.
+
+## [1.11.1] - 2015-12-21 (backfilled 2016-04-25)
+### Changed
+- Use `path.Base` in `Name` and `HelpName`
+- Export `GetName` on flag types.
+
+### Fixed
+- Flag parsing when skipping is enabled.
+- Test output cleanup.
+- Move completion check to account for empty input case.
+
+## [1.11.0] - 2015-11-15 (backfilled 2016-04-25)
+### Added
+- Destination scan support for flags.
+- Testing against `tip` in Travis CI config.
+
+### Changed
+- Go version in Travis CI config.
+
+### Fixed
+- Removed redundant tests.
+- Use correct example naming in tests.
+
+## [1.10.2] - 2015-10-29 (backfilled 2016-04-25)
+### Fixed
+- Remove unused var in bash completion.
+
+## [1.10.1] - 2015-10-21 (backfilled 2016-04-25)
+### Added
+- Coverage and reference logos in README.
+
+### Fixed
+- Use specified values in help and version parsing.
+- Only display app version and help message once.
+
+## [1.10.0] - 2015-10-06 (backfilled 2016-04-25)
+### Added
+- More tests for existing functionality.
+- `ArgsUsage` at app and command level for help text flexibility.
+
+### Fixed
+- Honor `HideHelp` and `HideVersion` in `App.Run`.
+- Remove juvenile word from README.
+
+## [1.9.0] - 2015-09-08 (backfilled 2016-04-25)
+### Added
+- `FullName` on command with accompanying help output update.
+- Set default `$PROG` in bash completion.
+
+### Changed
+- Docs formatting.
+
+### Fixed
+- Removed self-referential imports in tests.
+
+## [1.8.0] - 2015-06-30 (backfilled 2016-04-25)
+### Added
+- Support for `Copyright` at app level.
+- `Parent` func at context level to walk up context lineage.
+
+### Fixed
+- Global flag processing at top level.
+
+## [1.7.1] - 2015-06-11 (backfilled 2016-04-25)
+### Added
+- Aggregate errors from `Before`/`After` funcs.
+- Doc comments on flag structs.
+- Include non-global flags when checking version and help.
+- Travis CI config updates.
+
+### Fixed
+- Ensure slice type flags have non-nil values.
+- Collect global flags from the full command hierarchy.
+- Docs prose.
+
+## [1.7.0] - 2015-05-03 (backfilled 2016-04-25)
+### Changed
+- `HelpPrinter` signature includes output writer.
+
+### Fixed
+- Specify go 1.1+ in docs.
+- Set `Writer` when running command as app.
+
+## [1.6.0] - 2015-03-23 (backfilled 2016-04-25)
+### Added
+- Multiple author support.
+- `NumFlags` at context level.
+- `Aliases` at command level.
+
+### Deprecated
+- `ShortName` at command level.
+
+### Fixed
+- Subcommand help output.
+- Backward compatible support for deprecated `Author` and `Email` fields.
+- Docs regarding `Names`/`Aliases`.
+
+## [1.5.0] - 2015-02-20 (backfilled 2016-04-25)
+### Added
+- `After` hook func support at app and command level.
+
+### Fixed
+- Use parsed context when running command as subcommand.
+- Docs prose.
+
+## [1.4.1] - 2015-01-09 (backfilled 2016-04-25)
+### Added
+- Support for hiding `-h / --help` flags, but not `help` subcommand.
+- Stop flag parsing after `--`.
+
+### Fixed
+- Help text for generic flags to specify single value.
+- Use double quotes in output for defaults.
+- Use `ParseInt` instead of `ParseUint` for int environment var values.
+- Use `0` as base when parsing int environment var values.
+
+## [1.4.0] - 2014-12-12 (backfilled 2016-04-25)
+### Added
+- Support for environment variable lookup "cascade".
+- Support for `Stdout` on app for output redirection.
+
+### Fixed
+- Print command help instead of app help in `ShowCommandHelp`.
+
+## [1.3.1] - 2014-11-13 (backfilled 2016-04-25)
+### Added
+- Docs and example code updates.
+
+### Changed
+- Default `-v / --version` flag made optional.
+
+## [1.3.0] - 2014-08-10 (backfilled 2016-04-25)
+### Added
+- `FlagNames` at context level.
+- Exposed `VersionPrinter` var for more control over version output.
+- Zsh completion hook.
+- `AUTHOR` section in default app help template.
+- Contribution guidelines.
+- `DurationFlag` type.
+
+## [1.2.0] - 2014-08-02
+### Added
+- Support for environment variable defaults on flags plus tests.
+
+## [1.1.0] - 2014-07-15
+### Added
+- Bash completion.
+- Optional hiding of built-in help command.
+- Optional skipping of flag parsing at command level.
+- `Author`, `Email`, and `Compiled` metadata on app.
+- `Before` hook func support at app and command level.
+- `CommandNotFound` func support at app level.
+- Command reference available on context.
+- `GenericFlag` type.
+- `Float64Flag` type.
+- `BoolTFlag` type.
+- `IsSet` flag helper on context.
+- More flag lookup funcs at context level.
+- More tests &amp; docs.
+
+### Changed
+- Help template updates to account for presence/absence of flags.
+- Separated subcommand help template.
+- Exposed `HelpPrinter` var for more control over help output.
+
+## [1.0.0] - 2013-11-01
+### Added
+- `help` flag in default app flag set and each command flag set.
+- Custom handling of argument parsing errors.
+- Command lookup by name at app level.
+- `StringSliceFlag` type and supporting `StringSlice` type.
+- `IntSliceFlag` type and supporting `IntSlice` type.
+- Slice type flag lookups by name at context level.
+- Export of app and command help functions.
+- More tests &amp; docs.
+
+## 0.1.0 - 2013-07-22
+### Added
+- Initial implementation.
+
+[Unreleased]: https://github.com/urfave/cli/compare/v1.18.0...HEAD
+[1.18.0]: https://github.com/urfave/cli/compare/v1.17.0...v1.18.0
+[1.17.0]: https://github.com/urfave/cli/compare/v1.16.0...v1.17.0
+[1.16.0]: https://github.com/urfave/cli/compare/v1.15.0...v1.16.0
+[1.15.0]: https://github.com/urfave/cli/compare/v1.14.0...v1.15.0
+[1.14.0]: https://github.com/urfave/cli/compare/v1.13.0...v1.14.0
+[1.13.0]: https://github.com/urfave/cli/compare/v1.12.0...v1.13.0
+[1.12.0]: https://github.com/urfave/cli/compare/v1.11.1...v1.12.0
+[1.11.1]: https://github.com/urfave/cli/compare/v1.11.0...v1.11.1
+[1.11.0]: https://github.com/urfave/cli/compare/v1.10.2...v1.11.0
+[1.10.2]: https://github.com/urfave/cli/compare/v1.10.1...v1.10.2
+[1.10.1]: https://github.com/urfave/cli/compare/v1.10.0...v1.10.1
+[1.10.0]: https://github.com/urfave/cli/compare/v1.9.0...v1.10.0
+[1.9.0]: https://github.com/urfave/cli/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/urfave/cli/compare/v1.7.1...v1.8.0
+[1.7.1]: https://github.com/urfave/cli/compare/v1.7.0...v1.7.1
+[1.7.0]: https://github.com/urfave/cli/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/urfave/cli/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/urfave/cli/compare/v1.4.1...v1.5.0
+[1.4.1]: https://github.com/urfave/cli/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/urfave/cli/compare/v1.3.1...v1.4.0
+[1.3.1]: https://github.com/urfave/cli/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/urfave/cli/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/urfave/cli/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/urfave/cli/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/urfave/cli/compare/v0.1.0...v1.0.0

--- a/vendor/github.com/urfave/cli/LICENSE
+++ b/vendor/github.com/urfave/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Jeremy Saenz & Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/urfave/cli/README.md
+++ b/vendor/github.com/urfave/cli/README.md
@@ -1,0 +1,1364 @@
+cli
+===
+
+[![Build Status](https://travis-ci.org/urfave/cli.svg?branch=master)](https://travis-ci.org/urfave/cli)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/rtgk5xufi932pb2v?svg=true)](https://ci.appveyor.com/project/urfave/cli)
+[![GoDoc](https://godoc.org/github.com/urfave/cli?status.svg)](https://godoc.org/github.com/urfave/cli)
+[![codebeat](https://codebeat.co/badges/0a8f30aa-f975-404b-b878-5fab3ae1cc5f)](https://codebeat.co/projects/github-com-urfave-cli)
+[![Go Report Card](https://goreportcard.com/badge/urfave/cli)](https://goreportcard.com/report/urfave/cli)
+[![top level coverage](https://gocover.io/_badge/github.com/urfave/cli?0 "top level coverage")](http://gocover.io/github.com/urfave/cli) /
+[![altsrc coverage](https://gocover.io/_badge/github.com/urfave/cli/altsrc?0 "altsrc coverage")](http://gocover.io/github.com/urfave/cli/altsrc)
+
+**Notice:** This is the library formerly known as
+`github.com/codegangsta/cli` -- Github will automatically redirect requests
+to this repository, but we recommend updating your references for clarity.
+
+cli is a simple, fast, and fun package for building command line apps in Go. The
+goal is to enable developers to write fast and distributable command line
+applications in an expressive way.
+
+<!-- toc -->
+
+- [Overview](#overview)
+- [Installation](#installation)
+  * [Supported platforms](#supported-platforms)
+  * [Using the `v2` branch](#using-the-v2-branch)
+  * [Pinning to the `v1` releases](#pinning-to-the-v1-releases)
+- [Getting Started](#getting-started)
+- [Examples](#examples)
+  * [Arguments](#arguments)
+  * [Flags](#flags)
+    + [Placeholder Values](#placeholder-values)
+    + [Alternate Names](#alternate-names)
+    + [Ordering](#ordering)
+    + [Values from the Environment](#values-from-the-environment)
+    + [Values from alternate input sources (YAML, TOML, and others)](#values-from-alternate-input-sources-yaml-toml-and-others)
+  * [Subcommands](#subcommands)
+  * [Subcommands categories](#subcommands-categories)
+  * [Exit code](#exit-code)
+  * [Bash Completion](#bash-completion)
+    + [Enabling](#enabling)
+    + [Distribution](#distribution)
+    + [Customization](#customization)
+  * [Generated Help Text](#generated-help-text)
+    + [Customization](#customization-1)
+  * [Version Flag](#version-flag)
+    + [Customization](#customization-2)
+    + [Full API Example](#full-api-example)
+- [Contribution Guidelines](#contribution-guidelines)
+
+<!-- tocstop -->
+
+## Overview
+
+Command line apps are usually so tiny that there is absolutely no reason why
+your code should *not* be self-documenting. Things like generating help text and
+parsing command flags/options should not hinder productivity when writing a
+command line app.
+
+**This is where cli comes into play.** cli makes command line programming fun,
+organized, and expressive!
+
+## Installation
+
+Make sure you have a working Go environment.  Go version 1.2+ is supported.  [See
+the install instructions for Go](http://golang.org/doc/install.html).
+
+To install cli, simply run:
+```
+$ go get github.com/urfave/cli
+```
+
+Make sure your `PATH` includes the `$GOPATH/bin` directory so your commands can
+be easily used:
+```
+export PATH=$PATH:$GOPATH/bin
+```
+
+### Supported platforms
+
+cli is tested against multiple versions of Go on Linux, and against the latest
+released version of Go on OS X and Windows.  For full details, see
+[`./.travis.yml`](./.travis.yml) and [`./appveyor.yml`](./appveyor.yml).
+
+### Using the `v2` branch
+
+**Warning**: The `v2` branch is currently unreleased and considered unstable.
+
+There is currently a long-lived branch named `v2` that is intended to land as
+the new `master` branch once development there has settled down.  The current
+`master` branch (mirrored as `v1`) is being manually merged into `v2` on
+an irregular human-based schedule, but generally if one wants to "upgrade" to
+`v2` *now* and accept the volatility (read: "awesomeness") that comes along with
+that, please use whatever version pinning of your preference, such as via
+`gopkg.in`:
+
+```
+$ go get gopkg.in/urfave/cli.v2
+```
+
+``` go
+...
+import (
+  "gopkg.in/urfave/cli.v2" // imports as package "cli"
+)
+...
+```
+
+### Pinning to the `v1` releases
+
+Similarly to the section above describing use of the `v2` branch, if one wants
+to avoid any unexpected compatibility pains once `v2` becomes `master`, then
+pinning to `v1` is an acceptable option, e.g.:
+
+```
+$ go get gopkg.in/urfave/cli.v1
+```
+
+``` go
+...
+import (
+  "gopkg.in/urfave/cli.v1" // imports as package "cli"
+)
+...
+```
+
+This will pull the latest tagged `v1` release (e.g. `v1.18.1` at the time of writing).
+
+## Getting Started
+
+One of the philosophies behind cli is that an API should be playful and full of
+discovery. So a cli app can be as little as one line of code in `main()`.
+
+<!-- {
+  "args": ["&#45;&#45;help"],
+  "output": "A new cli application"
+} -->
+``` go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  cli.NewApp().Run(os.Args)
+}
+```
+
+This app will run and show help text, but is not very useful. Let's give an
+action to execute and some help documentation:
+
+<!-- {
+  "output": "boom! I say!"
+} -->
+``` go
+package main
+
+import (
+  "fmt"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+  app.Name = "boom"
+  app.Usage = "make an explosive entrance"
+  app.Action = func(c *cli.Context) error {
+    fmt.Println("boom! I say!")
+    return nil
+  }
+
+  app.Run(os.Args)
+}
+```
+
+Running this already gives you a ton of functionality, plus support for things
+like subcommands and flags, which are covered below.
+
+## Examples
+
+Being a programmer can be a lonely job. Thankfully by the power of automation
+that is not the case! Let's create a greeter app to fend off our demons of
+loneliness!
+
+Start by creating a directory named `greet`, and within it, add a file,
+`greet.go` with the following code in it:
+
+<!-- {
+  "output": "Hello friend!"
+} -->
+``` go
+package main
+
+import (
+  "fmt"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+  app.Name = "greet"
+  app.Usage = "fight the loneliness!"
+  app.Action = func(c *cli.Context) error {
+    fmt.Println("Hello friend!")
+    return nil
+  }
+
+  app.Run(os.Args)
+}
+```
+
+Install our command to the `$GOPATH/bin` directory:
+
+```
+$ go install
+```
+
+Finally run our new command:
+
+```
+$ greet
+Hello friend!
+```
+
+cli also generates neat help text:
+
+```
+$ greet help
+NAME:
+    greet - fight the loneliness!
+
+USAGE:
+    greet [global options] command [command options] [arguments...]
+
+VERSION:
+    0.0.0
+
+COMMANDS:
+    help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS
+    --version Shows version information
+```
+
+### Arguments
+
+You can lookup arguments by calling the `Args` function on `cli.Context`, e.g.:
+
+<!-- {
+  "output": "Hello \""
+} -->
+``` go
+package main
+
+import (
+  "fmt"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Action = func(c *cli.Context) error {
+    fmt.Printf("Hello %q", c.Args().Get(0))
+    return nil
+  }
+
+  app.Run(os.Args)
+}
+```
+
+### Flags
+
+Setting and querying flags is simple.
+
+<!-- {
+  "output": "Hello Nefertiti"
+} -->
+``` go
+package main
+
+import (
+  "fmt"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Flags = []cli.Flag {
+    cli.StringFlag{
+      Name: "lang",
+      Value: "english",
+      Usage: "language for the greeting",
+    },
+  }
+
+  app.Action = func(c *cli.Context) error {
+    name := "Nefertiti"
+    if c.NArg() > 0 {
+      name = c.Args().Get(0)
+    }
+    if c.String("lang") == "spanish" {
+      fmt.Println("Hola", name)
+    } else {
+      fmt.Println("Hello", name)
+    }
+    return nil
+  }
+
+  app.Run(os.Args)
+}
+```
+
+You can also set a destination variable for a flag, to which the content will be
+scanned.
+
+<!-- {
+  "output": "Hello someone"
+} -->
+``` go
+package main
+
+import (
+  "os"
+  "fmt"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  var language string
+
+  app := cli.NewApp()
+
+  app.Flags = []cli.Flag {
+    cli.StringFlag{
+      Name:        "lang",
+      Value:       "english",
+      Usage:       "language for the greeting",
+      Destination: &language,
+    },
+  }
+
+  app.Action = func(c *cli.Context) error {
+    name := "someone"
+    if c.NArg() > 0 {
+      name = c.Args()[0]
+    }
+    if language == "spanish" {
+      fmt.Println("Hola", name)
+    } else {
+      fmt.Println("Hello", name)
+    }
+    return nil
+  }
+
+  app.Run(os.Args)
+}
+```
+
+See full list of flags at http://godoc.org/github.com/urfave/cli
+
+#### Placeholder Values
+
+Sometimes it's useful to specify a flag's value within the usage string itself.
+Such placeholders are indicated with back quotes.
+
+For example this:
+
+<!-- {
+  "args": ["&#45;&#45;help"],
+  "output": "&#45;&#45;config FILE, &#45;c FILE"
+} -->
+```go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Flags = []cli.Flag{
+    cli.StringFlag{
+      Name:  "config, c",
+      Usage: "Load configuration from `FILE`",
+    },
+  }
+
+  app.Run(os.Args)
+}
+```
+
+Will result in help output like:
+
+```
+--config FILE, -c FILE   Load configuration from FILE
+```
+
+Note that only the first placeholder is used. Subsequent back-quoted words will
+be left as-is.
+
+#### Alternate Names
+
+You can set alternate (or short) names for flags by providing a comma-delimited
+list for the `Name`. e.g.
+
+<!-- {
+  "args": ["&#45;&#45;help"],
+  "output": "&#45;&#45;lang value, &#45;l value.*language for the greeting.*default: \"english\""
+} -->
+``` go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Flags = []cli.Flag {
+    cli.StringFlag{
+      Name: "lang, l",
+      Value: "english",
+      Usage: "language for the greeting",
+    },
+  }
+
+  app.Run(os.Args)
+}
+```
+
+That flag can then be set with `--lang spanish` or `-l spanish`. Note that
+giving two different forms of the same flag in the same command invocation is an
+error.
+
+#### Ordering
+
+Flags for the application and commands are shown in the order they are defined.
+However, it's possible to sort them from outside this library by using `FlagsByName`
+with `sort`.
+
+For example this:
+
+<!-- {
+  "args": ["&#45;&#45;help"],
+  "output": "Load configuration from FILE\n.*Language for the greeting.*"
+} -->
+``` go
+package main
+
+import (
+  "os"
+  "sort"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Flags = []cli.Flag {
+    cli.StringFlag{
+      Name: "lang, l",
+      Value: "english",
+      Usage: "Language for the greeting",
+    },
+    cli.StringFlag{
+      Name: "config, c",
+      Usage: "Load configuration from `FILE`",
+    },
+  }
+
+  sort.Sort(cli.FlagsByName(app.Flags))
+
+  app.Run(os.Args)
+}
+```
+
+Will result in help output like:
+
+```
+--config FILE, -c FILE  Load configuration from FILE
+--lang value, -l value  Language for the greeting (default: "english")
+```
+
+#### Values from the Environment
+
+You can also have the default value set from the environment via `EnvVar`.  e.g.
+
+<!-- {
+  "args": ["&#45;&#45;help"],
+  "output": "language for the greeting.*APP_LANG"
+} -->
+``` go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Flags = []cli.Flag {
+    cli.StringFlag{
+      Name: "lang, l",
+      Value: "english",
+      Usage: "language for the greeting",
+      EnvVar: "APP_LANG",
+    },
+  }
+
+  app.Run(os.Args)
+}
+```
+
+The `EnvVar` may also be given as a comma-delimited "cascade", where the first
+environment variable that resolves is used as the default.
+
+<!-- {
+  "args": ["&#45;&#45;help"],
+  "output": "language for the greeting.*LEGACY_COMPAT_LANG.*APP_LANG.*LANG"
+} -->
+``` go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Flags = []cli.Flag {
+    cli.StringFlag{
+      Name: "lang, l",
+      Value: "english",
+      Usage: "language for the greeting",
+      EnvVar: "LEGACY_COMPAT_LANG,APP_LANG,LANG",
+    },
+  }
+
+  app.Run(os.Args)
+}
+```
+
+#### Values from alternate input sources (YAML, TOML, and others)
+
+There is a separate package altsrc that adds support for getting flag values
+from other file input sources.
+
+Currently supported input source formats:
+* YAML
+* TOML
+
+In order to get values for a flag from an alternate input source the following
+code would be added to wrap an existing cli.Flag like below:
+
+``` go
+  altsrc.NewIntFlag(cli.IntFlag{Name: "test"})
+```
+
+Initialization must also occur for these flags. Below is an example initializing
+getting data from a yaml file below.
+
+``` go
+  command.Before = altsrc.InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+```
+
+The code above will use the "load" string as a flag name to get the file name of
+a yaml file from the cli.Context.  It will then use that file name to initialize
+the yaml input source for any flags that are defined on that command.  As a note
+the "load" flag used would also have to be defined on the command flags in order
+for this code snipped to work.
+
+Currently only the aboved specified formats are supported but developers can
+add support for other input sources by implementing the
+altsrc.InputSourceContext for their given sources.
+
+Here is a more complete sample of a command using YAML support:
+
+<!-- {
+  "args": ["test-cmd", "&#45;&#45;help"],
+  "output": "&#45&#45;test value.*default: 0"
+} -->
+``` go
+package notmain
+
+import (
+  "fmt"
+  "os"
+
+  "github.com/urfave/cli"
+  "github.com/urfave/cli/altsrc"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  flags := []cli.Flag{
+    altsrc.NewIntFlag(cli.IntFlag{Name: "test"}),
+    cli.StringFlag{Name: "load"},
+  }
+
+  app.Action = func(c *cli.Context) error {
+    fmt.Println("yaml ist rad")
+    return nil
+  }
+
+  app.Before = altsrc.InitInputSourceWithContext(flags, altsrc.NewYamlSourceFromFlagFunc("load"))
+  app.Flags = flags
+
+  app.Run(os.Args)
+}
+```
+
+### Subcommands
+
+Subcommands can be defined for a more git-like command line app.
+
+<!-- {
+  "args": ["template", "add"],
+  "output": "new task template: .+"
+} -->
+```go
+package main
+
+import (
+  "fmt"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Commands = []cli.Command{
+    {
+      Name:    "add",
+      Aliases: []string{"a"},
+      Usage:   "add a task to the list",
+      Action:  func(c *cli.Context) error {
+        fmt.Println("added task: ", c.Args().First())
+        return nil
+      },
+    },
+    {
+      Name:    "complete",
+      Aliases: []string{"c"},
+      Usage:   "complete a task on the list",
+      Action:  func(c *cli.Context) error {
+        fmt.Println("completed task: ", c.Args().First())
+        return nil
+      },
+    },
+    {
+      Name:        "template",
+      Aliases:     []string{"t"},
+      Usage:       "options for task templates",
+      Subcommands: []cli.Command{
+        {
+          Name:  "add",
+          Usage: "add a new template",
+          Action: func(c *cli.Context) error {
+            fmt.Println("new task template: ", c.Args().First())
+            return nil
+          },
+        },
+        {
+          Name:  "remove",
+          Usage: "remove an existing template",
+          Action: func(c *cli.Context) error {
+            fmt.Println("removed task template: ", c.Args().First())
+            return nil
+          },
+        },
+      },
+    },
+  }
+
+  app.Run(os.Args)
+}
+```
+
+### Subcommands categories
+
+For additional organization in apps that have many subcommands, you can
+associate a category for each command to group them together in the help
+output.
+
+E.g.
+
+```go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Commands = []cli.Command{
+    {
+      Name: "noop",
+    },
+    {
+      Name:     "add",
+      Category: "template",
+    },
+    {
+      Name:     "remove",
+      Category: "template",
+    },
+  }
+
+  app.Run(os.Args)
+}
+```
+
+Will include:
+
+```
+COMMANDS:
+    noop
+
+  Template actions:
+    add
+    remove
+```
+
+### Exit code
+
+Calling `App.Run` will not automatically call `os.Exit`, which means that by
+default the exit code will "fall through" to being `0`.  An explicit exit code
+may be set by returning a non-nil error that fulfills `cli.ExitCoder`, *or* a
+`cli.MultiError` that includes an error that fulfills `cli.ExitCoder`, e.g.:
+
+``` go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+  app.Flags = []cli.Flag{
+    cli.BoolTFlag{
+      Name:  "ginger-crouton",
+      Usage: "is it in the soup?",
+    },
+  }
+  app.Action = func(ctx *cli.Context) error {
+    if !ctx.Bool("ginger-crouton") {
+      return cli.NewExitError("it is not in the soup", 86)
+    }
+    return nil
+  }
+
+  app.Run(os.Args)
+}
+```
+
+### Bash Completion
+
+You can enable completion commands by setting the `EnableBashCompletion`
+flag on the `App` object.  By default, this setting will only auto-complete to
+show an app's subcommands, but you can write your own completion methods for
+the App or its subcommands.
+
+<!-- {
+  "args": ["complete", "&#45;&#45;generate&#45;bash&#45;completion"],
+  "output": "laundry"
+} -->
+``` go
+package main
+
+import (
+  "fmt"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  tasks := []string{"cook", "clean", "laundry", "eat", "sleep", "code"}
+
+  app := cli.NewApp()
+  app.EnableBashCompletion = true
+  app.Commands = []cli.Command{
+    {
+      Name:  "complete",
+      Aliases: []string{"c"},
+      Usage: "complete a task on the list",
+      Action: func(c *cli.Context) error {
+         fmt.Println("completed task: ", c.Args().First())
+         return nil
+      },
+      BashComplete: func(c *cli.Context) {
+        // This will complete if no args are passed
+        if c.NArg() > 0 {
+          return
+        }
+        for _, t := range tasks {
+          fmt.Println(t)
+        }
+      },
+    },
+  }
+
+  app.Run(os.Args)
+}
+```
+
+#### Enabling
+
+Source the `autocomplete/bash_autocomplete` file in your `.bashrc` file while
+setting the `PROG` variable to the name of your program:
+
+`PROG=myprogram source /.../cli/autocomplete/bash_autocomplete`
+
+#### Distribution
+
+Copy `autocomplete/bash_autocomplete` into `/etc/bash_completion.d/` and rename
+it to the name of the program you wish to add autocomplete support for (or
+automatically install it there if you are distributing a package). Don't forget
+to source the file to make it active in the current shell.
+
+```
+sudo cp src/bash_autocomplete /etc/bash_completion.d/<myprogram>
+source /etc/bash_completion.d/<myprogram>
+```
+
+Alternatively, you can just document that users should source the generic
+`autocomplete/bash_autocomplete` in their bash configuration with `$PROG` set
+to the name of their program (as above).
+
+#### Customization
+
+The default bash completion flag (`--generate-bash-completion`) is defined as
+`cli.BashCompletionFlag`, and may be redefined if desired, e.g.:
+
+<!-- {
+  "args": ["&#45;&#45;compgen"],
+  "output": "wat\nhelp\nh"
+} -->
+``` go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  cli.BashCompletionFlag = cli.BoolFlag{
+    Name:   "compgen",
+    Hidden: true,
+  }
+
+  app := cli.NewApp()
+  app.EnableBashCompletion = true
+  app.Commands = []cli.Command{
+    {
+      Name: "wat",
+    },
+  }
+  app.Run(os.Args)
+}
+```
+
+### Generated Help Text
+
+The default help flag (`-h/--help`) is defined as `cli.HelpFlag` and is checked
+by the cli internals in order to print generated help text for the app, command,
+or subcommand, and break execution.
+
+#### Customization
+
+All of the help text generation may be customized, and at multiple levels.  The
+templates are exposed as variables `AppHelpTemplate`, `CommandHelpTemplate`, and
+`SubcommandHelpTemplate` which may be reassigned or augmented, and full override
+is possible by assigning a compatible func to the `cli.HelpPrinter` variable,
+e.g.:
+
+<!-- {
+  "output": "Ha HA.  I pwnd the help!!1"
+} -->
+``` go
+package main
+
+import (
+  "fmt"
+  "io"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  // EXAMPLE: Append to an existing template
+  cli.AppHelpTemplate = fmt.Sprintf(`%s
+
+WEBSITE: http://awesometown.example.com
+
+SUPPORT: support@awesometown.example.com
+
+`, cli.AppHelpTemplate)
+
+  // EXAMPLE: Override a template
+  cli.AppHelpTemplate = `NAME:
+   {{.Name}} - {{.Usage}}
+USAGE:
+   {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command
+[command options]{{end}} {{if
+.ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
+   {{if len .Authors}}
+AUTHOR(S):
+   {{range .Authors}}{{ . }}{{end}}
+   {{end}}{{if .Commands}}
+COMMANDS:
+{{range .Commands}}{{if not .HideHelp}}   {{join .Names ", "}}{{ "\t"
+}}{{.Usage}}{{ "\n" }}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+GLOBAL OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}{{if .Copyright }}
+COPYRIGHT:
+   {{.Copyright}}
+   {{end}}{{if .Version}}
+VERSION:
+   {{.Version}}
+   {{end}}
+`
+
+  // EXAMPLE: Replace the `HelpPrinter` func
+  cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+    fmt.Println("Ha HA.  I pwnd the help!!1")
+  }
+
+  cli.NewApp().Run(os.Args)
+}
+```
+
+The default flag may be customized to something other than `-h/--help` by
+setting `cli.HelpFlag`, e.g.:
+
+<!-- {
+  "args": ["&#45;&#45halp"],
+  "output": "haaaaalp.*HALP"
+} -->
+``` go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  cli.HelpFlag = cli.BoolFlag{
+    Name: "halp, haaaaalp",
+    Usage: "HALP",
+    EnvVar: "SHOW_HALP,HALPPLZ",
+  }
+
+  cli.NewApp().Run(os.Args)
+}
+```
+
+### Version Flag
+
+The default version flag (`-v/--version`) is defined as `cli.VersionFlag`, which
+is checked by the cli internals in order to print the `App.Version` via
+`cli.VersionPrinter` and break execution.
+
+#### Customization
+
+The default flag may be customized to something other than `-v/--version` by
+setting `cli.VersionFlag`, e.g.:
+
+<!-- {
+  "args": ["&#45;&#45print-version"],
+  "output": "partay version 19\\.99\\.0"
+} -->
+``` go
+package main
+
+import (
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  cli.VersionFlag = cli.BoolFlag{
+    Name: "print-version, V",
+    Usage: "print only the version",
+  }
+
+  app := cli.NewApp()
+  app.Name = "partay"
+  app.Version = "19.99.0"
+  app.Run(os.Args)
+}
+```
+
+Alternatively, the version printer at `cli.VersionPrinter` may be overridden, e.g.:
+
+<!-- {
+  "args": ["&#45;&#45version"],
+  "output": "version=19\\.99\\.0 revision=fafafaf"
+} -->
+``` go
+package main
+
+import (
+  "fmt"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+var (
+  Revision = "fafafaf"
+)
+
+func main() {
+  cli.VersionPrinter = func(c *cli.Context) {
+    fmt.Printf("version=%s revision=%s\n", c.App.Version, Revision)
+  }
+
+  app := cli.NewApp()
+  app.Name = "partay"
+  app.Version = "19.99.0"
+  app.Run(os.Args)
+}
+```
+
+#### Full API Example
+
+**Notice**: This is a contrived (functioning) example meant strictly for API
+demonstration purposes.  Use of one's imagination is encouraged.
+
+<!-- {
+  "output": "made it!\nPhew!"
+} -->
+``` go
+package main
+
+import (
+  "errors"
+  "flag"
+  "fmt"
+  "io"
+  "io/ioutil"
+  "os"
+  "time"
+
+  "github.com/urfave/cli"
+)
+
+func init() {
+  cli.AppHelpTemplate += "\nCUSTOMIZED: you bet ur muffins\n"
+  cli.CommandHelpTemplate += "\nYMMV\n"
+  cli.SubcommandHelpTemplate += "\nor something\n"
+
+  cli.HelpFlag = cli.BoolFlag{Name: "halp"}
+  cli.BashCompletionFlag = cli.BoolFlag{Name: "compgen", Hidden: true}
+  cli.VersionFlag = cli.BoolFlag{Name: "print-version, V"}
+
+  cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+    fmt.Fprintf(w, "best of luck to you\n")
+  }
+  cli.VersionPrinter = func(c *cli.Context) {
+    fmt.Fprintf(c.App.Writer, "version=%s\n", c.App.Version)
+  }
+  cli.OsExiter = func(c int) {
+    fmt.Fprintf(cli.ErrWriter, "refusing to exit %d\n", c)
+  }
+  cli.ErrWriter = ioutil.Discard
+  cli.FlagStringer = func(fl cli.Flag) string {
+    return fmt.Sprintf("\t\t%s", fl.GetName())
+  }
+}
+
+type hexWriter struct{}
+
+func (w *hexWriter) Write(p []byte) (int, error) {
+  for _, b := range p {
+    fmt.Printf("%x", b)
+  }
+  fmt.Printf("\n")
+
+  return len(p), nil
+}
+
+type genericType struct{
+  s string
+}
+
+func (g *genericType) Set(value string) error {
+  g.s = value
+  return nil
+}
+
+func (g *genericType) String() string {
+  return g.s
+}
+
+func main() {
+  app := cli.NewApp()
+  app.Name = "kənˈtrīv"
+  app.Version = "19.99.0"
+  app.Compiled = time.Now()
+  app.Authors = []cli.Author{
+    cli.Author{
+      Name:  "Example Human",
+      Email: "human@example.com",
+    },
+  }
+  app.Copyright = "(c) 1999 Serious Enterprise"
+  app.HelpName = "contrive"
+  app.Usage = "demonstrate available API"
+  app.UsageText = "contrive - demonstrating the available API"
+  app.ArgsUsage = "[args and such]"
+  app.Commands = []cli.Command{
+    cli.Command{
+      Name:        "doo",
+      Aliases:     []string{"do"},
+      Category:    "motion",
+      Usage:       "do the doo",
+      UsageText:   "doo - does the dooing",
+      Description: "no really, there is a lot of dooing to be done",
+      ArgsUsage:   "[arrgh]",
+      Flags: []cli.Flag{
+        cli.BoolFlag{Name: "forever, forevvarr"},
+      },
+      Subcommands: cli.Commands{
+        cli.Command{
+          Name:   "wop",
+          Action: wopAction,
+        },
+      },
+      SkipFlagParsing: false,
+      HideHelp:        false,
+      Hidden:          false,
+      HelpName:        "doo!",
+      BashComplete: func(c *cli.Context) {
+        fmt.Fprintf(c.App.Writer, "--better\n")
+      },
+      Before: func(c *cli.Context) error {
+        fmt.Fprintf(c.App.Writer, "brace for impact\n")
+        return nil
+      },
+      After: func(c *cli.Context) error {
+        fmt.Fprintf(c.App.Writer, "did we lose anyone?\n")
+        return nil
+      },
+      Action: func(c *cli.Context) error {
+        c.Command.FullName()
+        c.Command.HasName("wop")
+        c.Command.Names()
+        c.Command.VisibleFlags()
+        fmt.Fprintf(c.App.Writer, "dodododododoodododddooooododododooo\n")
+        if c.Bool("forever") {
+          c.Command.Run(c)
+        }
+        return nil
+      },
+      OnUsageError: func(c *cli.Context, err error, isSubcommand bool) error {
+        fmt.Fprintf(c.App.Writer, "for shame\n")
+        return err
+      },
+    },
+  }
+  app.Flags = []cli.Flag{
+    cli.BoolFlag{Name: "fancy"},
+    cli.BoolTFlag{Name: "fancier"},
+    cli.DurationFlag{Name: "howlong, H", Value: time.Second * 3},
+    cli.Float64Flag{Name: "howmuch"},
+    cli.GenericFlag{Name: "wat", Value: &genericType{}},
+    cli.Int64Flag{Name: "longdistance"},
+    cli.Int64SliceFlag{Name: "intervals"},
+    cli.IntFlag{Name: "distance"},
+    cli.IntSliceFlag{Name: "times"},
+    cli.StringFlag{Name: "dance-move, d"},
+    cli.StringSliceFlag{Name: "names, N"},
+    cli.UintFlag{Name: "age"},
+    cli.Uint64Flag{Name: "bigage"},
+  }
+  app.EnableBashCompletion = true
+  app.HideHelp = false
+  app.HideVersion = false
+  app.BashComplete = func(c *cli.Context) {
+    fmt.Fprintf(c.App.Writer, "lipstick\nkiss\nme\nlipstick\nringo\n")
+  }
+  app.Before = func(c *cli.Context) error {
+    fmt.Fprintf(c.App.Writer, "HEEEERE GOES\n")
+    return nil
+  }
+  app.After = func(c *cli.Context) error {
+    fmt.Fprintf(c.App.Writer, "Phew!\n")
+    return nil
+  }
+  app.CommandNotFound = func(c *cli.Context, command string) {
+    fmt.Fprintf(c.App.Writer, "Thar be no %q here.\n", command)
+  }
+  app.OnUsageError = func(c *cli.Context, err error, isSubcommand bool) error {
+    if isSubcommand {
+      return err
+    }
+
+    fmt.Fprintf(c.App.Writer, "WRONG: %#v\n", err)
+    return nil
+  }
+  app.Action = func(c *cli.Context) error {
+    cli.DefaultAppComplete(c)
+    cli.HandleExitCoder(errors.New("not an exit coder, though"))
+    cli.ShowAppHelp(c)
+    cli.ShowCommandCompletions(c, "nope")
+    cli.ShowCommandHelp(c, "also-nope")
+    cli.ShowCompletions(c)
+    cli.ShowSubcommandHelp(c)
+    cli.ShowVersion(c)
+
+    categories := c.App.Categories()
+    categories.AddCommand("sounds", cli.Command{
+      Name: "bloop",
+    })
+
+    for _, category := range c.App.Categories() {
+      fmt.Fprintf(c.App.Writer, "%s\n", category.Name)
+      fmt.Fprintf(c.App.Writer, "%#v\n", category.Commands)
+      fmt.Fprintf(c.App.Writer, "%#v\n", category.VisibleCommands())
+    }
+
+    fmt.Printf("%#v\n", c.App.Command("doo"))
+    if c.Bool("infinite") {
+      c.App.Run([]string{"app", "doo", "wop"})
+    }
+
+    if c.Bool("forevar") {
+      c.App.RunAsSubcommand(c)
+    }
+    c.App.Setup()
+    fmt.Printf("%#v\n", c.App.VisibleCategories())
+    fmt.Printf("%#v\n", c.App.VisibleCommands())
+    fmt.Printf("%#v\n", c.App.VisibleFlags())
+
+    fmt.Printf("%#v\n", c.Args().First())
+    if len(c.Args()) > 0 {
+      fmt.Printf("%#v\n", c.Args()[1])
+    }
+    fmt.Printf("%#v\n", c.Args().Present())
+    fmt.Printf("%#v\n", c.Args().Tail())
+
+    set := flag.NewFlagSet("contrive", 0)
+    nc := cli.NewContext(c.App, set, c)
+
+    fmt.Printf("%#v\n", nc.Args())
+    fmt.Printf("%#v\n", nc.Bool("nope"))
+    fmt.Printf("%#v\n", nc.BoolT("nerp"))
+    fmt.Printf("%#v\n", nc.Duration("howlong"))
+    fmt.Printf("%#v\n", nc.Float64("hay"))
+    fmt.Printf("%#v\n", nc.Generic("bloop"))
+    fmt.Printf("%#v\n", nc.Int64("bonk"))
+    fmt.Printf("%#v\n", nc.Int64Slice("burnks"))
+    fmt.Printf("%#v\n", nc.Int("bips"))
+    fmt.Printf("%#v\n", nc.IntSlice("blups"))
+    fmt.Printf("%#v\n", nc.String("snurt"))
+    fmt.Printf("%#v\n", nc.StringSlice("snurkles"))
+    fmt.Printf("%#v\n", nc.Uint("flub"))
+    fmt.Printf("%#v\n", nc.Uint64("florb"))
+    fmt.Printf("%#v\n", nc.GlobalBool("global-nope"))
+    fmt.Printf("%#v\n", nc.GlobalBoolT("global-nerp"))
+    fmt.Printf("%#v\n", nc.GlobalDuration("global-howlong"))
+    fmt.Printf("%#v\n", nc.GlobalFloat64("global-hay"))
+    fmt.Printf("%#v\n", nc.GlobalGeneric("global-bloop"))
+    fmt.Printf("%#v\n", nc.GlobalInt("global-bips"))
+    fmt.Printf("%#v\n", nc.GlobalIntSlice("global-blups"))
+    fmt.Printf("%#v\n", nc.GlobalString("global-snurt"))
+    fmt.Printf("%#v\n", nc.GlobalStringSlice("global-snurkles"))
+
+    fmt.Printf("%#v\n", nc.FlagNames())
+    fmt.Printf("%#v\n", nc.GlobalFlagNames())
+    fmt.Printf("%#v\n", nc.GlobalIsSet("wat"))
+    fmt.Printf("%#v\n", nc.GlobalSet("wat", "nope"))
+    fmt.Printf("%#v\n", nc.NArg())
+    fmt.Printf("%#v\n", nc.NumFlags())
+    fmt.Printf("%#v\n", nc.Parent())
+
+    nc.Set("wat", "also-nope")
+
+    ec := cli.NewExitError("ohwell", 86)
+    fmt.Fprintf(c.App.Writer, "%d", ec.ExitCode())
+    fmt.Printf("made it!\n")
+    return ec
+  }
+
+  if os.Getenv("HEXY") != "" {
+    app.Writer = &hexWriter{}
+    app.ErrWriter = &hexWriter{}
+  }
+
+  app.Metadata = map[string]interface{}{
+    "layers":     "many",
+    "explicable": false,
+    "whatever-values": 19.99,
+  }
+
+  app.Run(os.Args)
+}
+
+func wopAction(c *cli.Context) error {
+  fmt.Fprintf(c.App.Writer, ":wave: over here, eh\n")
+  return nil
+}
+```
+
+## Contribution Guidelines
+
+Feel free to put up a pull request to fix a bug or maybe add a feature. I will
+give it a code review and make sure that it does not break backwards
+compatibility. If I or any other collaborators agree that it is in line with
+the vision of the project, we will work with you to get the code into
+a mergeable state and merge it into the master branch.
+
+If you have contributed something significant to the project, we will most
+likely add you as a collaborator. As a collaborator you are given the ability
+to merge others pull requests. It is very important that new code does not
+break existing code, so be careful about what code you do choose to merge.
+
+If you feel like you have contributed to the project but have not yet been
+added as a collaborator, we probably forgot to add you, please open an issue.

--- a/vendor/github.com/urfave/cli/altsrc/altsrc.go
+++ b/vendor/github.com/urfave/cli/altsrc/altsrc.go
@@ -1,0 +1,3 @@
+package altsrc
+
+//go:generate python ../generate-flag-types altsrc -i ../flag-types.json -o flag_generated.go

--- a/vendor/github.com/urfave/cli/altsrc/flag.go
+++ b/vendor/github.com/urfave/cli/altsrc/flag.go
@@ -1,0 +1,261 @@
+package altsrc
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+// FlagInputSourceExtension is an extension interface of cli.Flag that
+// allows a value to be set on the existing parsed flags.
+type FlagInputSourceExtension interface {
+	cli.Flag
+	ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error
+}
+
+// ApplyInputSourceValues iterates over all provided flags and
+// executes ApplyInputSourceValue on flags implementing the
+// FlagInputSourceExtension interface to initialize these flags
+// to an alternate input source.
+func ApplyInputSourceValues(context *cli.Context, inputSourceContext InputSourceContext, flags []cli.Flag) error {
+	for _, f := range flags {
+		inputSourceExtendedFlag, isType := f.(FlagInputSourceExtension)
+		if isType {
+			err := inputSourceExtendedFlag.ApplyInputSourceValue(context, inputSourceContext)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// InitInputSource is used to to setup an InputSourceContext on a cli.Command Before method. It will create a new
+// input source based on the func provided. If there is no error it will then apply the new input source to any flags
+// that are supported by the input source
+func InitInputSource(flags []cli.Flag, createInputSource func() (InputSourceContext, error)) cli.BeforeFunc {
+	return func(context *cli.Context) error {
+		inputSource, err := createInputSource()
+		if err != nil {
+			return fmt.Errorf("Unable to create input source: inner error: \n'%v'", err.Error())
+		}
+
+		return ApplyInputSourceValues(context, inputSource, flags)
+	}
+}
+
+// InitInputSourceWithContext is used to to setup an InputSourceContext on a cli.Command Before method. It will create a new
+// input source based on the func provided with potentially using existing cli.Context values to initialize itself. If there is
+// no error it will then apply the new input source to any flags that are supported by the input source
+func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(context *cli.Context) (InputSourceContext, error)) cli.BeforeFunc {
+	return func(context *cli.Context) error {
+		inputSource, err := createInputSource(context)
+		if err != nil {
+			return fmt.Errorf("Unable to create input source with context: inner error: \n'%v'", err.Error())
+		}
+
+		return ApplyInputSourceValues(context, inputSource, flags)
+	}
+}
+
+// ApplyInputSourceValue applies a generic value to the flagSet if required
+func (f *GenericFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+	if f.set != nil {
+		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVar) {
+			value, err := isc.Generic(f.GenericFlag.Name)
+			if err != nil {
+				return err
+			}
+			if value != nil {
+				eachName(f.Name, func(name string) {
+					f.set.Set(f.Name, value.String())
+				})
+			}
+		}
+	}
+
+	return nil
+}
+
+// ApplyInputSourceValue applies a StringSlice value to the flagSet if required
+func (f *StringSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+	if f.set != nil {
+		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVar) {
+			value, err := isc.StringSlice(f.StringSliceFlag.Name)
+			if err != nil {
+				return err
+			}
+			if value != nil {
+				var sliceValue cli.StringSlice = value
+				eachName(f.Name, func(name string) {
+					underlyingFlag := f.set.Lookup(f.Name)
+					if underlyingFlag != nil {
+						underlyingFlag.Value = &sliceValue
+					}
+				})
+			}
+		}
+	}
+	return nil
+}
+
+// ApplyInputSourceValue applies a IntSlice value if required
+func (f *IntSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+	if f.set != nil {
+		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVar) {
+			value, err := isc.IntSlice(f.IntSliceFlag.Name)
+			if err != nil {
+				return err
+			}
+			if value != nil {
+				var sliceValue cli.IntSlice = value
+				eachName(f.Name, func(name string) {
+					underlyingFlag := f.set.Lookup(f.Name)
+					if underlyingFlag != nil {
+						underlyingFlag.Value = &sliceValue
+					}
+				})
+			}
+		}
+	}
+	return nil
+}
+
+// ApplyInputSourceValue applies a Bool value to the flagSet if required
+func (f *BoolFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+	if f.set != nil {
+		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVar) {
+			value, err := isc.Bool(f.BoolFlag.Name)
+			if err != nil {
+				return err
+			}
+			if value {
+				eachName(f.Name, func(name string) {
+					f.set.Set(f.Name, strconv.FormatBool(value))
+				})
+			}
+		}
+	}
+	return nil
+}
+
+// ApplyInputSourceValue applies a BoolT value to the flagSet if required
+func (f *BoolTFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+	if f.set != nil {
+		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVar) {
+			value, err := isc.BoolT(f.BoolTFlag.Name)
+			if err != nil {
+				return err
+			}
+			if !value {
+				eachName(f.Name, func(name string) {
+					f.set.Set(f.Name, strconv.FormatBool(value))
+				})
+			}
+		}
+	}
+	return nil
+}
+
+// ApplyInputSourceValue applies a String value to the flagSet if required
+func (f *StringFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+	if f.set != nil {
+		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVar)) {
+			value, err := isc.String(f.StringFlag.Name)
+			if err != nil {
+				return err
+			}
+			if value != "" {
+				eachName(f.Name, func(name string) {
+					f.set.Set(f.Name, value)
+				})
+			}
+		}
+	}
+	return nil
+}
+
+// ApplyInputSourceValue applies a int value to the flagSet if required
+func (f *IntFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+	if f.set != nil {
+		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVar)) {
+			value, err := isc.Int(f.IntFlag.Name)
+			if err != nil {
+				return err
+			}
+			if value > 0 {
+				eachName(f.Name, func(name string) {
+					f.set.Set(f.Name, strconv.FormatInt(int64(value), 10))
+				})
+			}
+		}
+	}
+	return nil
+}
+
+// ApplyInputSourceValue applies a Duration value to the flagSet if required
+func (f *DurationFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+	if f.set != nil {
+		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVar)) {
+			value, err := isc.Duration(f.DurationFlag.Name)
+			if err != nil {
+				return err
+			}
+			if value > 0 {
+				eachName(f.Name, func(name string) {
+					f.set.Set(f.Name, value.String())
+				})
+			}
+		}
+	}
+	return nil
+}
+
+// ApplyInputSourceValue applies a Float64 value to the flagSet if required
+func (f *Float64Flag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+	if f.set != nil {
+		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVar)) {
+			value, err := isc.Float64(f.Float64Flag.Name)
+			if err != nil {
+				return err
+			}
+			if value > 0 {
+				floatStr := float64ToString(value)
+				eachName(f.Name, func(name string) {
+					f.set.Set(f.Name, floatStr)
+				})
+			}
+		}
+	}
+	return nil
+}
+
+func isEnvVarSet(envVars string) bool {
+	for _, envVar := range strings.Split(envVars, ",") {
+		envVar = strings.TrimSpace(envVar)
+		if _, ok := syscall.Getenv(envVar); ok {
+			// TODO: Can't use this for bools as
+			// set means that it was true or false based on
+			// Bool flag type, should work for other types
+			return true
+		}
+	}
+
+	return false
+}
+
+func float64ToString(f float64) string {
+	return fmt.Sprintf("%v", f)
+}
+
+func eachName(longName string, fn func(string)) {
+	parts := strings.Split(longName, ",")
+	for _, name := range parts {
+		name = strings.Trim(name, " ")
+		fn(name)
+	}
+}

--- a/vendor/github.com/urfave/cli/altsrc/flag_generated.go
+++ b/vendor/github.com/urfave/cli/altsrc/flag_generated.go
@@ -1,0 +1,347 @@
+package altsrc
+
+import (
+	"flag"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+// WARNING: This file is generated!
+
+// BoolFlag is the flag type that wraps cli.BoolFlag to allow
+// for other values to be specified
+type BoolFlag struct {
+	cli.BoolFlag
+	set *flag.FlagSet
+}
+
+// NewBoolFlag creates a new BoolFlag
+func NewBoolFlag(fl cli.BoolFlag) *BoolFlag {
+	return &BoolFlag{BoolFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped BoolFlag.Apply
+func (f *BoolFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.BoolFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped BoolFlag.ApplyWithError
+func (f *BoolFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.BoolFlag.ApplyWithError(set)
+}
+
+// BoolTFlag is the flag type that wraps cli.BoolTFlag to allow
+// for other values to be specified
+type BoolTFlag struct {
+	cli.BoolTFlag
+	set *flag.FlagSet
+}
+
+// NewBoolTFlag creates a new BoolTFlag
+func NewBoolTFlag(fl cli.BoolTFlag) *BoolTFlag {
+	return &BoolTFlag{BoolTFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped BoolTFlag.Apply
+func (f *BoolTFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.BoolTFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped BoolTFlag.ApplyWithError
+func (f *BoolTFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.BoolTFlag.ApplyWithError(set)
+}
+
+// DurationFlag is the flag type that wraps cli.DurationFlag to allow
+// for other values to be specified
+type DurationFlag struct {
+	cli.DurationFlag
+	set *flag.FlagSet
+}
+
+// NewDurationFlag creates a new DurationFlag
+func NewDurationFlag(fl cli.DurationFlag) *DurationFlag {
+	return &DurationFlag{DurationFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped DurationFlag.Apply
+func (f *DurationFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.DurationFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped DurationFlag.ApplyWithError
+func (f *DurationFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.DurationFlag.ApplyWithError(set)
+}
+
+// Float64Flag is the flag type that wraps cli.Float64Flag to allow
+// for other values to be specified
+type Float64Flag struct {
+	cli.Float64Flag
+	set *flag.FlagSet
+}
+
+// NewFloat64Flag creates a new Float64Flag
+func NewFloat64Flag(fl cli.Float64Flag) *Float64Flag {
+	return &Float64Flag{Float64Flag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped Float64Flag.Apply
+func (f *Float64Flag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.Float64Flag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped Float64Flag.ApplyWithError
+func (f *Float64Flag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.Float64Flag.ApplyWithError(set)
+}
+
+// GenericFlag is the flag type that wraps cli.GenericFlag to allow
+// for other values to be specified
+type GenericFlag struct {
+	cli.GenericFlag
+	set *flag.FlagSet
+}
+
+// NewGenericFlag creates a new GenericFlag
+func NewGenericFlag(fl cli.GenericFlag) *GenericFlag {
+	return &GenericFlag{GenericFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped GenericFlag.Apply
+func (f *GenericFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.GenericFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped GenericFlag.ApplyWithError
+func (f *GenericFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.GenericFlag.ApplyWithError(set)
+}
+
+// Int64Flag is the flag type that wraps cli.Int64Flag to allow
+// for other values to be specified
+type Int64Flag struct {
+	cli.Int64Flag
+	set *flag.FlagSet
+}
+
+// NewInt64Flag creates a new Int64Flag
+func NewInt64Flag(fl cli.Int64Flag) *Int64Flag {
+	return &Int64Flag{Int64Flag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped Int64Flag.Apply
+func (f *Int64Flag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.Int64Flag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped Int64Flag.ApplyWithError
+func (f *Int64Flag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.Int64Flag.ApplyWithError(set)
+}
+
+// IntFlag is the flag type that wraps cli.IntFlag to allow
+// for other values to be specified
+type IntFlag struct {
+	cli.IntFlag
+	set *flag.FlagSet
+}
+
+// NewIntFlag creates a new IntFlag
+func NewIntFlag(fl cli.IntFlag) *IntFlag {
+	return &IntFlag{IntFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped IntFlag.Apply
+func (f *IntFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.IntFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped IntFlag.ApplyWithError
+func (f *IntFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.IntFlag.ApplyWithError(set)
+}
+
+// IntSliceFlag is the flag type that wraps cli.IntSliceFlag to allow
+// for other values to be specified
+type IntSliceFlag struct {
+	cli.IntSliceFlag
+	set *flag.FlagSet
+}
+
+// NewIntSliceFlag creates a new IntSliceFlag
+func NewIntSliceFlag(fl cli.IntSliceFlag) *IntSliceFlag {
+	return &IntSliceFlag{IntSliceFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped IntSliceFlag.Apply
+func (f *IntSliceFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.IntSliceFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped IntSliceFlag.ApplyWithError
+func (f *IntSliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.IntSliceFlag.ApplyWithError(set)
+}
+
+// Int64SliceFlag is the flag type that wraps cli.Int64SliceFlag to allow
+// for other values to be specified
+type Int64SliceFlag struct {
+	cli.Int64SliceFlag
+	set *flag.FlagSet
+}
+
+// NewInt64SliceFlag creates a new Int64SliceFlag
+func NewInt64SliceFlag(fl cli.Int64SliceFlag) *Int64SliceFlag {
+	return &Int64SliceFlag{Int64SliceFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped Int64SliceFlag.Apply
+func (f *Int64SliceFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.Int64SliceFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped Int64SliceFlag.ApplyWithError
+func (f *Int64SliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.Int64SliceFlag.ApplyWithError(set)
+}
+
+// StringFlag is the flag type that wraps cli.StringFlag to allow
+// for other values to be specified
+type StringFlag struct {
+	cli.StringFlag
+	set *flag.FlagSet
+}
+
+// NewStringFlag creates a new StringFlag
+func NewStringFlag(fl cli.StringFlag) *StringFlag {
+	return &StringFlag{StringFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped StringFlag.Apply
+func (f *StringFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.StringFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped StringFlag.ApplyWithError
+func (f *StringFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.StringFlag.ApplyWithError(set)
+}
+
+// StringSliceFlag is the flag type that wraps cli.StringSliceFlag to allow
+// for other values to be specified
+type StringSliceFlag struct {
+	cli.StringSliceFlag
+	set *flag.FlagSet
+}
+
+// NewStringSliceFlag creates a new StringSliceFlag
+func NewStringSliceFlag(fl cli.StringSliceFlag) *StringSliceFlag {
+	return &StringSliceFlag{StringSliceFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped StringSliceFlag.Apply
+func (f *StringSliceFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.StringSliceFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped StringSliceFlag.ApplyWithError
+func (f *StringSliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.StringSliceFlag.ApplyWithError(set)
+}
+
+// Uint64Flag is the flag type that wraps cli.Uint64Flag to allow
+// for other values to be specified
+type Uint64Flag struct {
+	cli.Uint64Flag
+	set *flag.FlagSet
+}
+
+// NewUint64Flag creates a new Uint64Flag
+func NewUint64Flag(fl cli.Uint64Flag) *Uint64Flag {
+	return &Uint64Flag{Uint64Flag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped Uint64Flag.Apply
+func (f *Uint64Flag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.Uint64Flag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped Uint64Flag.ApplyWithError
+func (f *Uint64Flag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.Uint64Flag.ApplyWithError(set)
+}
+
+// UintFlag is the flag type that wraps cli.UintFlag to allow
+// for other values to be specified
+type UintFlag struct {
+	cli.UintFlag
+	set *flag.FlagSet
+}
+
+// NewUintFlag creates a new UintFlag
+func NewUintFlag(fl cli.UintFlag) *UintFlag {
+	return &UintFlag{UintFlag: fl, set: nil}
+}
+
+// Apply saves the flagSet for later usage calls, then calls the
+// wrapped UintFlag.Apply
+func (f *UintFlag) Apply(set *flag.FlagSet) {
+	f.set = set
+	f.UintFlag.Apply(set)
+}
+
+// ApplyWithError saves the flagSet for later usage calls, then calls the
+// wrapped UintFlag.ApplyWithError
+func (f *UintFlag) ApplyWithError(set *flag.FlagSet) error {
+	f.set = set
+	return f.UintFlag.ApplyWithError(set)
+}

--- a/vendor/github.com/urfave/cli/altsrc/flag_test.go
+++ b/vendor/github.com/urfave/cli/altsrc/flag_test.go
@@ -1,0 +1,336 @@
+package altsrc
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+type testApplyInputSource struct {
+	Flag               FlagInputSourceExtension
+	FlagName           string
+	FlagSetName        string
+	Expected           string
+	ContextValueString string
+	ContextValue       flag.Value
+	EnvVarValue        string
+	EnvVarName         string
+	MapValue           interface{}
+}
+
+func TestGenericApplyInputSourceValue(t *testing.T) {
+	v := &Parser{"abc", "def"}
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewGenericFlag(cli.GenericFlag{Name: "test", Value: &Parser{}}),
+		FlagName: "test",
+		MapValue: v,
+	})
+	expect(t, v, c.Generic("test"))
+}
+
+func TestGenericApplyInputSourceMethodContextSet(t *testing.T) {
+	p := &Parser{"abc", "def"}
+	c := runTest(t, testApplyInputSource{
+		Flag:               NewGenericFlag(cli.GenericFlag{Name: "test", Value: &Parser{}}),
+		FlagName:           "test",
+		MapValue:           &Parser{"efg", "hig"},
+		ContextValueString: p.String(),
+	})
+	expect(t, p, c.Generic("test"))
+}
+
+func TestGenericApplyInputSourceMethodEnvVarSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:        NewGenericFlag(cli.GenericFlag{Name: "test", Value: &Parser{}, EnvVar: "TEST"}),
+		FlagName:    "test",
+		MapValue:    &Parser{"efg", "hij"},
+		EnvVarName:  "TEST",
+		EnvVarValue: "abc,def",
+	})
+	expect(t, &Parser{"abc", "def"}, c.Generic("test"))
+}
+
+func TestStringSliceApplyInputSourceValue(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewStringSliceFlag(cli.StringSliceFlag{Name: "test"}),
+		FlagName: "test",
+		MapValue: []string{"hello", "world"},
+	})
+	expect(t, c.StringSlice("test"), []string{"hello", "world"})
+}
+
+func TestStringSliceApplyInputSourceMethodContextSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:               NewStringSliceFlag(cli.StringSliceFlag{Name: "test"}),
+		FlagName:           "test",
+		MapValue:           []string{"hello", "world"},
+		ContextValueString: "ohno",
+	})
+	expect(t, c.StringSlice("test"), []string{"ohno"})
+}
+
+func TestStringSliceApplyInputSourceMethodEnvVarSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:        NewStringSliceFlag(cli.StringSliceFlag{Name: "test", EnvVar: "TEST"}),
+		FlagName:    "test",
+		MapValue:    []string{"hello", "world"},
+		EnvVarName:  "TEST",
+		EnvVarValue: "oh,no",
+	})
+	expect(t, c.StringSlice("test"), []string{"oh", "no"})
+}
+
+func TestIntSliceApplyInputSourceValue(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewIntSliceFlag(cli.IntSliceFlag{Name: "test"}),
+		FlagName: "test",
+		MapValue: []int{1, 2},
+	})
+	expect(t, c.IntSlice("test"), []int{1, 2})
+}
+
+func TestIntSliceApplyInputSourceMethodContextSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:               NewIntSliceFlag(cli.IntSliceFlag{Name: "test"}),
+		FlagName:           "test",
+		MapValue:           []int{1, 2},
+		ContextValueString: "3",
+	})
+	expect(t, c.IntSlice("test"), []int{3})
+}
+
+func TestIntSliceApplyInputSourceMethodEnvVarSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:        NewIntSliceFlag(cli.IntSliceFlag{Name: "test", EnvVar: "TEST"}),
+		FlagName:    "test",
+		MapValue:    []int{1, 2},
+		EnvVarName:  "TEST",
+		EnvVarValue: "3,4",
+	})
+	expect(t, c.IntSlice("test"), []int{3, 4})
+}
+
+func TestBoolApplyInputSourceMethodSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewBoolFlag(cli.BoolFlag{Name: "test"}),
+		FlagName: "test",
+		MapValue: true,
+	})
+	expect(t, true, c.Bool("test"))
+}
+
+func TestBoolApplyInputSourceMethodContextSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:               NewBoolFlag(cli.BoolFlag{Name: "test"}),
+		FlagName:           "test",
+		MapValue:           false,
+		ContextValueString: "true",
+	})
+	expect(t, true, c.Bool("test"))
+}
+
+func TestBoolApplyInputSourceMethodEnvVarSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:        NewBoolFlag(cli.BoolFlag{Name: "test", EnvVar: "TEST"}),
+		FlagName:    "test",
+		MapValue:    false,
+		EnvVarName:  "TEST",
+		EnvVarValue: "true",
+	})
+	expect(t, true, c.Bool("test"))
+}
+
+func TestBoolTApplyInputSourceMethodSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewBoolTFlag(cli.BoolTFlag{Name: "test"}),
+		FlagName: "test",
+		MapValue: false,
+	})
+	expect(t, false, c.BoolT("test"))
+}
+
+func TestBoolTApplyInputSourceMethodContextSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:               NewBoolTFlag(cli.BoolTFlag{Name: "test"}),
+		FlagName:           "test",
+		MapValue:           true,
+		ContextValueString: "false",
+	})
+	expect(t, false, c.BoolT("test"))
+}
+
+func TestBoolTApplyInputSourceMethodEnvVarSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:        NewBoolTFlag(cli.BoolTFlag{Name: "test", EnvVar: "TEST"}),
+		FlagName:    "test",
+		MapValue:    true,
+		EnvVarName:  "TEST",
+		EnvVarValue: "false",
+	})
+	expect(t, false, c.BoolT("test"))
+}
+
+func TestStringApplyInputSourceMethodSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewStringFlag(cli.StringFlag{Name: "test"}),
+		FlagName: "test",
+		MapValue: "hello",
+	})
+	expect(t, "hello", c.String("test"))
+}
+
+func TestStringApplyInputSourceMethodContextSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:               NewStringFlag(cli.StringFlag{Name: "test"}),
+		FlagName:           "test",
+		MapValue:           "hello",
+		ContextValueString: "goodbye",
+	})
+	expect(t, "goodbye", c.String("test"))
+}
+
+func TestStringApplyInputSourceMethodEnvVarSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:        NewStringFlag(cli.StringFlag{Name: "test", EnvVar: "TEST"}),
+		FlagName:    "test",
+		MapValue:    "hello",
+		EnvVarName:  "TEST",
+		EnvVarValue: "goodbye",
+	})
+	expect(t, "goodbye", c.String("test"))
+}
+
+func TestIntApplyInputSourceMethodSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewIntFlag(cli.IntFlag{Name: "test"}),
+		FlagName: "test",
+		MapValue: 15,
+	})
+	expect(t, 15, c.Int("test"))
+}
+
+func TestIntApplyInputSourceMethodContextSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:               NewIntFlag(cli.IntFlag{Name: "test"}),
+		FlagName:           "test",
+		MapValue:           15,
+		ContextValueString: "7",
+	})
+	expect(t, 7, c.Int("test"))
+}
+
+func TestIntApplyInputSourceMethodEnvVarSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:        NewIntFlag(cli.IntFlag{Name: "test", EnvVar: "TEST"}),
+		FlagName:    "test",
+		MapValue:    15,
+		EnvVarName:  "TEST",
+		EnvVarValue: "12",
+	})
+	expect(t, 12, c.Int("test"))
+}
+
+func TestDurationApplyInputSourceMethodSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewDurationFlag(cli.DurationFlag{Name: "test"}),
+		FlagName: "test",
+		MapValue: time.Duration(30 * time.Second),
+	})
+	expect(t, time.Duration(30*time.Second), c.Duration("test"))
+}
+
+func TestDurationApplyInputSourceMethodContextSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:               NewDurationFlag(cli.DurationFlag{Name: "test"}),
+		FlagName:           "test",
+		MapValue:           time.Duration(30 * time.Second),
+		ContextValueString: time.Duration(15 * time.Second).String(),
+	})
+	expect(t, time.Duration(15*time.Second), c.Duration("test"))
+}
+
+func TestDurationApplyInputSourceMethodEnvVarSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:        NewDurationFlag(cli.DurationFlag{Name: "test", EnvVar: "TEST"}),
+		FlagName:    "test",
+		MapValue:    time.Duration(30 * time.Second),
+		EnvVarName:  "TEST",
+		EnvVarValue: time.Duration(15 * time.Second).String(),
+	})
+	expect(t, time.Duration(15*time.Second), c.Duration("test"))
+}
+
+func TestFloat64ApplyInputSourceMethodSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewFloat64Flag(cli.Float64Flag{Name: "test"}),
+		FlagName: "test",
+		MapValue: 1.3,
+	})
+	expect(t, 1.3, c.Float64("test"))
+}
+
+func TestFloat64ApplyInputSourceMethodContextSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:               NewFloat64Flag(cli.Float64Flag{Name: "test"}),
+		FlagName:           "test",
+		MapValue:           1.3,
+		ContextValueString: fmt.Sprintf("%v", 1.4),
+	})
+	expect(t, 1.4, c.Float64("test"))
+}
+
+func TestFloat64ApplyInputSourceMethodEnvVarSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:        NewFloat64Flag(cli.Float64Flag{Name: "test", EnvVar: "TEST"}),
+		FlagName:    "test",
+		MapValue:    1.3,
+		EnvVarName:  "TEST",
+		EnvVarValue: fmt.Sprintf("%v", 1.4),
+	})
+	expect(t, 1.4, c.Float64("test"))
+}
+
+func runTest(t *testing.T, test testApplyInputSource) *cli.Context {
+	inputSource := &MapInputSource{valueMap: map[interface{}]interface{}{test.FlagName: test.MapValue}}
+	set := flag.NewFlagSet(test.FlagSetName, flag.ContinueOnError)
+	c := cli.NewContext(nil, set, nil)
+	if test.EnvVarName != "" && test.EnvVarValue != "" {
+		os.Setenv(test.EnvVarName, test.EnvVarValue)
+		defer os.Setenv(test.EnvVarName, "")
+	}
+
+	test.Flag.Apply(set)
+	if test.ContextValue != nil {
+		flag := set.Lookup(test.FlagName)
+		flag.Value = test.ContextValue
+	}
+	if test.ContextValueString != "" {
+		set.Set(test.FlagName, test.ContextValueString)
+	}
+	test.Flag.ApplyInputSourceValue(c, inputSource)
+
+	return c
+}
+
+type Parser [2]string
+
+func (p *Parser) Set(value string) error {
+	parts := strings.Split(value, ",")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid format")
+	}
+
+	(*p)[0] = parts[0]
+	(*p)[1] = parts[1]
+
+	return nil
+}
+
+func (p *Parser) String() string {
+	return fmt.Sprintf("%s,%s", p[0], p[1])
+}

--- a/vendor/github.com/urfave/cli/altsrc/helpers_test.go
+++ b/vendor/github.com/urfave/cli/altsrc/helpers_test.go
@@ -1,0 +1,18 @@
+package altsrc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func expect(t *testing.T, a interface{}, b interface{}) {
+	if !reflect.DeepEqual(b, a) {
+		t.Errorf("Expected %#v (type %v) - Got %#v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	}
+}
+
+func refute(t *testing.T, a interface{}, b interface{}) {
+	if a == b {
+		t.Errorf("Did not expect %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	}
+}

--- a/vendor/github.com/urfave/cli/altsrc/input_source_context.go
+++ b/vendor/github.com/urfave/cli/altsrc/input_source_context.go
@@ -1,0 +1,21 @@
+package altsrc
+
+import (
+	"time"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+// InputSourceContext is an interface used to allow
+// other input sources to be implemented as needed.
+type InputSourceContext interface {
+	Int(name string) (int, error)
+	Duration(name string) (time.Duration, error)
+	Float64(name string) (float64, error)
+	String(name string) (string, error)
+	StringSlice(name string) ([]string, error)
+	IntSlice(name string) ([]int, error)
+	Generic(name string) (cli.Generic, error)
+	Bool(name string) (bool, error)
+	BoolT(name string) (bool, error)
+}

--- a/vendor/github.com/urfave/cli/altsrc/map_input_source.go
+++ b/vendor/github.com/urfave/cli/altsrc/map_input_source.go
@@ -1,0 +1,248 @@
+package altsrc
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+// MapInputSource implements InputSourceContext to return
+// data from the map that is loaded.
+type MapInputSource struct {
+	valueMap map[interface{}]interface{}
+}
+
+// nestedVal checks if the name has '.' delimiters.
+// If so, it tries to traverse the tree by the '.' delimited sections to find
+// a nested value for the key.
+func nestedVal(name string, tree map[interface{}]interface{}) (interface{}, bool) {
+	if sections := strings.Split(name, "."); len(sections) > 1 {
+		node := tree
+		for _, section := range sections[:len(sections)-1] {
+			if child, ok := node[section]; !ok {
+				return nil, false
+			} else {
+				if ctype, ok := child.(map[interface{}]interface{}); !ok {
+					return nil, false
+				} else {
+					node = ctype
+				}
+			}
+		}
+		if val, ok := node[sections[len(sections)-1]]; ok {
+			return val, true
+		}
+	}
+	return nil, false
+}
+
+// Int returns an int from the map if it exists otherwise returns 0
+func (fsm *MapInputSource) Int(name string) (int, error) {
+	otherGenericValue, exists := fsm.valueMap[name]
+	if exists {
+		otherValue, isType := otherGenericValue.(int)
+		if !isType {
+			return 0, incorrectTypeForFlagError(name, "int", otherGenericValue)
+		}
+		return otherValue, nil
+	}
+	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
+	if exists {
+		otherValue, isType := nestedGenericValue.(int)
+		if !isType {
+			return 0, incorrectTypeForFlagError(name, "int", nestedGenericValue)
+		}
+		return otherValue, nil
+	}
+
+	return 0, nil
+}
+
+// Duration returns a duration from the map if it exists otherwise returns 0
+func (fsm *MapInputSource) Duration(name string) (time.Duration, error) {
+	otherGenericValue, exists := fsm.valueMap[name]
+	if exists {
+		otherValue, isType := otherGenericValue.(time.Duration)
+		if !isType {
+			return 0, incorrectTypeForFlagError(name, "duration", otherGenericValue)
+		}
+		return otherValue, nil
+	}
+	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
+	if exists {
+		otherValue, isType := nestedGenericValue.(time.Duration)
+		if !isType {
+			return 0, incorrectTypeForFlagError(name, "duration", nestedGenericValue)
+		}
+		return otherValue, nil
+	}
+
+	return 0, nil
+}
+
+// Float64 returns an float64 from the map if it exists otherwise returns 0
+func (fsm *MapInputSource) Float64(name string) (float64, error) {
+	otherGenericValue, exists := fsm.valueMap[name]
+	if exists {
+		otherValue, isType := otherGenericValue.(float64)
+		if !isType {
+			return 0, incorrectTypeForFlagError(name, "float64", otherGenericValue)
+		}
+		return otherValue, nil
+	}
+	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
+	if exists {
+		otherValue, isType := nestedGenericValue.(float64)
+		if !isType {
+			return 0, incorrectTypeForFlagError(name, "float64", nestedGenericValue)
+		}
+		return otherValue, nil
+	}
+
+	return 0, nil
+}
+
+// String returns a string from the map if it exists otherwise returns an empty string
+func (fsm *MapInputSource) String(name string) (string, error) {
+	otherGenericValue, exists := fsm.valueMap[name]
+	if exists {
+		otherValue, isType := otherGenericValue.(string)
+		if !isType {
+			return "", incorrectTypeForFlagError(name, "string", otherGenericValue)
+		}
+		return otherValue, nil
+	}
+	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
+	if exists {
+		otherValue, isType := nestedGenericValue.(string)
+		if !isType {
+			return "", incorrectTypeForFlagError(name, "string", nestedGenericValue)
+		}
+		return otherValue, nil
+	}
+
+	return "", nil
+}
+
+// StringSlice returns an []string from the map if it exists otherwise returns nil
+func (fsm *MapInputSource) StringSlice(name string) ([]string, error) {
+	otherGenericValue, exists := fsm.valueMap[name]
+	if exists {
+		otherValue, isType := otherGenericValue.([]string)
+		if !isType {
+			return nil, incorrectTypeForFlagError(name, "[]string", otherGenericValue)
+		}
+		return otherValue, nil
+	}
+	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
+	if exists {
+		otherValue, isType := nestedGenericValue.([]string)
+		if !isType {
+			return nil, incorrectTypeForFlagError(name, "[]string", nestedGenericValue)
+		}
+		return otherValue, nil
+	}
+
+	return nil, nil
+}
+
+// IntSlice returns an []int from the map if it exists otherwise returns nil
+func (fsm *MapInputSource) IntSlice(name string) ([]int, error) {
+	otherGenericValue, exists := fsm.valueMap[name]
+	if exists {
+		otherValue, isType := otherGenericValue.([]int)
+		if !isType {
+			return nil, incorrectTypeForFlagError(name, "[]int", otherGenericValue)
+		}
+		return otherValue, nil
+	}
+	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
+	if exists {
+		otherValue, isType := nestedGenericValue.([]int)
+		if !isType {
+			return nil, incorrectTypeForFlagError(name, "[]int", nestedGenericValue)
+		}
+		return otherValue, nil
+	}
+
+	return nil, nil
+}
+
+// Generic returns an cli.Generic from the map if it exists otherwise returns nil
+func (fsm *MapInputSource) Generic(name string) (cli.Generic, error) {
+	otherGenericValue, exists := fsm.valueMap[name]
+	if exists {
+		otherValue, isType := otherGenericValue.(cli.Generic)
+		if !isType {
+			return nil, incorrectTypeForFlagError(name, "cli.Generic", otherGenericValue)
+		}
+		return otherValue, nil
+	}
+	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
+	if exists {
+		otherValue, isType := nestedGenericValue.(cli.Generic)
+		if !isType {
+			return nil, incorrectTypeForFlagError(name, "cli.Generic", nestedGenericValue)
+		}
+		return otherValue, nil
+	}
+
+	return nil, nil
+}
+
+// Bool returns an bool from the map otherwise returns false
+func (fsm *MapInputSource) Bool(name string) (bool, error) {
+	otherGenericValue, exists := fsm.valueMap[name]
+	if exists {
+		otherValue, isType := otherGenericValue.(bool)
+		if !isType {
+			return false, incorrectTypeForFlagError(name, "bool", otherGenericValue)
+		}
+		return otherValue, nil
+	}
+	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
+	if exists {
+		otherValue, isType := nestedGenericValue.(bool)
+		if !isType {
+			return false, incorrectTypeForFlagError(name, "bool", nestedGenericValue)
+		}
+		return otherValue, nil
+	}
+
+	return false, nil
+}
+
+// BoolT returns an bool from the map otherwise returns true
+func (fsm *MapInputSource) BoolT(name string) (bool, error) {
+	otherGenericValue, exists := fsm.valueMap[name]
+	if exists {
+		otherValue, isType := otherGenericValue.(bool)
+		if !isType {
+			return true, incorrectTypeForFlagError(name, "bool", otherGenericValue)
+		}
+		return otherValue, nil
+	}
+	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
+	if exists {
+		otherValue, isType := nestedGenericValue.(bool)
+		if !isType {
+			return true, incorrectTypeForFlagError(name, "bool", nestedGenericValue)
+		}
+		return otherValue, nil
+	}
+
+	return true, nil
+}
+
+func incorrectTypeForFlagError(name, expectedTypeName string, value interface{}) error {
+	valueType := reflect.TypeOf(value)
+	valueTypeName := ""
+	if valueType != nil {
+		valueTypeName = valueType.Name()
+	}
+
+	return fmt.Errorf("Mismatched type for flag '%s'. Expected '%s' but actual is '%s'", name, expectedTypeName, valueTypeName)
+}

--- a/vendor/github.com/urfave/cli/altsrc/toml_command_test.go
+++ b/vendor/github.com/urfave/cli/altsrc/toml_command_test.go
@@ -1,0 +1,310 @@
+// Disabling building of toml support in cases where golang is 1.0 or 1.1
+// as the encoding library is not implemented or supported.
+
+// +build go1.2
+
+package altsrc
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+func TestCommandTomFileTest(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.toml", []byte("test = 15"), 0666)
+	defer os.Remove("current.toml")
+	test := []string{"test-cmd", "--load", "current.toml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 15)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewTomlSourceFromFlagFunc("load"))
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandTomlFileTestGlobalEnvVarWins(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.toml", []byte("test = 15"), 0666)
+	defer os.Remove("current.toml")
+
+	os.Setenv("THE_TEST", "10")
+	defer os.Setenv("THE_TEST", "")
+	test := []string{"test-cmd", "--load", "current.toml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 10)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test", EnvVar: "THE_TEST"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewTomlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandTomlFileTestGlobalEnvVarWinsNested(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.toml", []byte("[top]\ntest = 15"), 0666)
+	defer os.Remove("current.toml")
+
+	os.Setenv("THE_TEST", "10")
+	defer os.Setenv("THE_TEST", "")
+	test := []string{"test-cmd", "--load", "current.toml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("top.test")
+			expect(t, val, 10)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "top.test", EnvVar: "THE_TEST"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewTomlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandTomlFileTestSpecifiedFlagWins(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.toml", []byte("test = 15"), 0666)
+	defer os.Remove("current.toml")
+
+	test := []string{"test-cmd", "--load", "current.toml", "--test", "7"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 7)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewTomlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandTomlFileTestSpecifiedFlagWinsNested(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.toml", []byte(`[top]
+  test = 15`), 0666)
+	defer os.Remove("current.toml")
+
+	test := []string{"test-cmd", "--load", "current.toml", "--top.test", "7"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("top.test")
+			expect(t, val, 7)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "top.test"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewTomlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandTomlFileTestDefaultValueFileWins(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.toml", []byte("test = 15"), 0666)
+	defer os.Remove("current.toml")
+
+	test := []string{"test-cmd", "--load", "current.toml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 15)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test", Value: 7}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewTomlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandTomlFileTestDefaultValueFileWinsNested(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.toml", []byte("[top]\ntest = 15"), 0666)
+	defer os.Remove("current.toml")
+
+	test := []string{"test-cmd", "--load", "current.toml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("top.test")
+			expect(t, val, 15)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "top.test", Value: 7}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewTomlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandTomlFileFlagHasDefaultGlobalEnvTomlSetGlobalEnvWins(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.toml", []byte("test = 15"), 0666)
+	defer os.Remove("current.toml")
+
+	os.Setenv("THE_TEST", "11")
+	defer os.Setenv("THE_TEST", "")
+
+	test := []string{"test-cmd", "--load", "current.toml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 11)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test", Value: 7, EnvVar: "THE_TEST"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewTomlSourceFromFlagFunc("load"))
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandTomlFileFlagHasDefaultGlobalEnvTomlSetGlobalEnvWinsNested(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.toml", []byte("[top]\ntest = 15"), 0666)
+	defer os.Remove("current.toml")
+
+	os.Setenv("THE_TEST", "11")
+	defer os.Setenv("THE_TEST", "")
+
+	test := []string{"test-cmd", "--load", "current.toml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("top.test")
+			expect(t, val, 11)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "top.test", Value: 7, EnvVar: "THE_TEST"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewTomlSourceFromFlagFunc("load"))
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}

--- a/vendor/github.com/urfave/cli/altsrc/toml_file_loader.go
+++ b/vendor/github.com/urfave/cli/altsrc/toml_file_loader.go
@@ -1,0 +1,113 @@
+// Disabling building of toml support in cases where golang is 1.0 or 1.1
+// as the encoding library is not implemented or supported.
+
+// +build go1.2
+
+package altsrc
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/BurntSushi/toml"
+	"gopkg.in/urfave/cli.v1"
+)
+
+type tomlMap struct {
+	Map map[interface{}]interface{}
+}
+
+func unmarshalMap(i interface{}) (ret map[interface{}]interface{}, err error) {
+	ret = make(map[interface{}]interface{})
+	m := i.(map[string]interface{})
+	for key, val := range m {
+		v := reflect.ValueOf(val)
+		switch v.Kind() {
+		case reflect.Bool:
+			ret[key] = val.(bool)
+		case reflect.String:
+			ret[key] = val.(string)
+		case reflect.Int:
+			ret[key] = int(val.(int))
+		case reflect.Int8:
+			ret[key] = int(val.(int8))
+		case reflect.Int16:
+			ret[key] = int(val.(int16))
+		case reflect.Int32:
+			ret[key] = int(val.(int32))
+		case reflect.Int64:
+			ret[key] = int(val.(int64))
+		case reflect.Uint:
+			ret[key] = int(val.(uint))
+		case reflect.Uint8:
+			ret[key] = int(val.(uint8))
+		case reflect.Uint16:
+			ret[key] = int(val.(uint16))
+		case reflect.Uint32:
+			ret[key] = int(val.(uint32))
+		case reflect.Uint64:
+			ret[key] = int(val.(uint64))
+		case reflect.Float32:
+			ret[key] = float64(val.(float32))
+		case reflect.Float64:
+			ret[key] = float64(val.(float64))
+		case reflect.Map:
+			if tmp, err := unmarshalMap(val); err == nil {
+				ret[key] = tmp
+			} else {
+				return nil, err
+			}
+		case reflect.Array:
+			fallthrough // [todo] - Support array type
+		default:
+			return nil, fmt.Errorf("Unsupported: type = %#v", v.Kind())
+		}
+	}
+	return ret, nil
+}
+
+func (self *tomlMap) UnmarshalTOML(i interface{}) error {
+	if tmp, err := unmarshalMap(i); err == nil {
+		self.Map = tmp
+	} else {
+		return err
+	}
+	return nil
+}
+
+type tomlSourceContext struct {
+	FilePath string
+}
+
+// NewTomlSourceFromFile creates a new TOML InputSourceContext from a filepath.
+func NewTomlSourceFromFile(file string) (InputSourceContext, error) {
+	tsc := &tomlSourceContext{FilePath: file}
+	var results tomlMap = tomlMap{}
+	if err := readCommandToml(tsc.FilePath, &results); err != nil {
+		return nil, fmt.Errorf("Unable to load TOML file '%s': inner error: \n'%v'", tsc.FilePath, err.Error())
+	}
+	return &MapInputSource{valueMap: results.Map}, nil
+}
+
+// NewTomlSourceFromFlagFunc creates a new TOML InputSourceContext from a provided flag name and source context.
+func NewTomlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (InputSourceContext, error) {
+	return func(context *cli.Context) (InputSourceContext, error) {
+		filePath := context.String(flagFileName)
+		return NewTomlSourceFromFile(filePath)
+	}
+}
+
+func readCommandToml(filePath string, container interface{}) (err error) {
+	b, err := loadDataFrom(filePath)
+	if err != nil {
+		return err
+	}
+
+	err = toml.Unmarshal(b, container)
+	if err != nil {
+		return err
+	}
+
+	err = nil
+	return
+}

--- a/vendor/github.com/urfave/cli/altsrc/yaml_command_test.go
+++ b/vendor/github.com/urfave/cli/altsrc/yaml_command_test.go
@@ -1,0 +1,313 @@
+// Disabling building of yaml support in cases where golang is 1.0 or 1.1
+// as the encoding library is not implemented or supported.
+
+// +build go1.2
+
+package altsrc
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+func TestCommandYamlFileTest(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 15)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTestGlobalEnvVarWins(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+
+	os.Setenv("THE_TEST", "10")
+	defer os.Setenv("THE_TEST", "")
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 10)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test", EnvVar: "THE_TEST"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTestGlobalEnvVarWinsNested(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte(`top:
+  test: 15`), 0666)
+	defer os.Remove("current.yaml")
+
+	os.Setenv("THE_TEST", "10")
+	defer os.Setenv("THE_TEST", "")
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("top.test")
+			expect(t, val, 10)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "top.test", EnvVar: "THE_TEST"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTestSpecifiedFlagWins(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+
+	test := []string{"test-cmd", "--load", "current.yaml", "--test", "7"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 7)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTestSpecifiedFlagWinsNested(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte(`top:
+  test: 15`), 0666)
+	defer os.Remove("current.yaml")
+
+	test := []string{"test-cmd", "--load", "current.yaml", "--top.test", "7"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("top.test")
+			expect(t, val, 7)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "top.test"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTestDefaultValueFileWins(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 15)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test", Value: 7}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTestDefaultValueFileWinsNested(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte(`top:
+  test: 15`), 0666)
+	defer os.Remove("current.yaml")
+
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("top.test")
+			expect(t, val, 15)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "top.test", Value: 7}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileFlagHasDefaultGlobalEnvYamlSetGlobalEnvWins(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+
+	os.Setenv("THE_TEST", "11")
+	defer os.Setenv("THE_TEST", "")
+
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("test")
+			expect(t, val, 11)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "test", Value: 7, EnvVar: "THE_TEST"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileFlagHasDefaultGlobalEnvYamlSetGlobalEnvWinsNested(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte(`top:
+  test: 15`), 0666)
+	defer os.Remove("current.yaml")
+
+	os.Setenv("THE_TEST", "11")
+	defer os.Setenv("THE_TEST", "")
+
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, nil)
+
+	command := &cli.Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *cli.Context) error {
+			val := c.Int("top.test")
+			expect(t, val, 11)
+			return nil
+		},
+		Flags: []cli.Flag{
+			NewIntFlag(cli.IntFlag{Name: "top.test", Value: 7, EnvVar: "THE_TEST"}),
+			cli.StringFlag{Name: "load"}},
+	}
+	command.Before = InitInputSourceWithContext(command.Flags, NewYamlSourceFromFlagFunc("load"))
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}

--- a/vendor/github.com/urfave/cli/altsrc/yaml_file_loader.go
+++ b/vendor/github.com/urfave/cli/altsrc/yaml_file_loader.go
@@ -1,0 +1,84 @@
+// Disabling building of yaml support in cases where golang is 1.0 or 1.1
+// as the encoding library is not implemented or supported.
+
+// +build go1.2
+
+package altsrc
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+
+	"gopkg.in/urfave/cli.v1"
+
+	"gopkg.in/yaml.v2"
+)
+
+type yamlSourceContext struct {
+	FilePath string
+}
+
+// NewYamlSourceFromFile creates a new Yaml InputSourceContext from a filepath.
+func NewYamlSourceFromFile(file string) (InputSourceContext, error) {
+	ysc := &yamlSourceContext{FilePath: file}
+	var results map[interface{}]interface{}
+	err := readCommandYaml(ysc.FilePath, &results)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to load Yaml file '%s': inner error: \n'%v'", ysc.FilePath, err.Error())
+	}
+
+	return &MapInputSource{valueMap: results}, nil
+}
+
+// NewYamlSourceFromFlagFunc creates a new Yaml InputSourceContext from a provided flag name and source context.
+func NewYamlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (InputSourceContext, error) {
+	return func(context *cli.Context) (InputSourceContext, error) {
+		filePath := context.String(flagFileName)
+		return NewYamlSourceFromFile(filePath)
+	}
+}
+
+func readCommandYaml(filePath string, container interface{}) (err error) {
+	b, err := loadDataFrom(filePath)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(b, container)
+	if err != nil {
+		return err
+	}
+
+	err = nil
+	return
+}
+
+func loadDataFrom(filePath string) ([]byte, error) {
+	u, err := url.Parse(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Host != "" { // i have a host, now do i support the scheme?
+		switch u.Scheme {
+		case "http", "https":
+			res, err := http.Get(filePath)
+			if err != nil {
+				return nil, err
+			}
+			return ioutil.ReadAll(res.Body)
+		default:
+			return nil, fmt.Errorf("scheme of %s is unsupported", filePath)
+		}
+	} else if u.Path != "" { // i dont have a host, but I have a path. I am a local file.
+		if _, notFoundFileErr := os.Stat(filePath); notFoundFileErr != nil {
+			return nil, fmt.Errorf("Cannot read from file: '%s' because it does not exist.", filePath)
+		}
+		return ioutil.ReadFile(filePath)
+	} else {
+		return nil, fmt.Errorf("unable to determine how to load from path %s", filePath)
+	}
+}

--- a/vendor/github.com/urfave/cli/app.go
+++ b/vendor/github.com/urfave/cli/app.go
@@ -1,0 +1,492 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+var (
+	changeLogURL                    = "https://github.com/urfave/cli/blob/master/CHANGELOG.md"
+	appActionDeprecationURL         = fmt.Sprintf("%s#deprecated-cli-app-action-signature", changeLogURL)
+	runAndExitOnErrorDeprecationURL = fmt.Sprintf("%s#deprecated-cli-app-runandexitonerror", changeLogURL)
+
+	contactSysadmin = "This is an error in the application.  Please contact the distributor of this application if this is not you."
+
+	errInvalidActionType = NewExitError("ERROR invalid Action type. "+
+		fmt.Sprintf("Must be `func(*Context`)` or `func(*Context) error).  %s", contactSysadmin)+
+		fmt.Sprintf("See %s", appActionDeprecationURL), 2)
+)
+
+// App is the main structure of a cli application. It is recommended that
+// an app be created with the cli.NewApp() function
+type App struct {
+	// The name of the program. Defaults to path.Base(os.Args[0])
+	Name string
+	// Full name of command for help, defaults to Name
+	HelpName string
+	// Description of the program.
+	Usage string
+	// Text to override the USAGE section of help
+	UsageText string
+	// Description of the program argument format.
+	ArgsUsage string
+	// Version of the program
+	Version string
+	// Description of the program
+	Description string
+	// List of commands to execute
+	Commands []Command
+	// List of flags to parse
+	Flags []Flag
+	// Boolean to enable bash completion commands
+	EnableBashCompletion bool
+	// Boolean to hide built-in help command
+	HideHelp bool
+	// Boolean to hide built-in version flag and the VERSION section of help
+	HideVersion bool
+	// Populate on app startup, only gettable through method Categories()
+	categories CommandCategories
+	// An action to execute when the bash-completion flag is set
+	BashComplete BashCompleteFunc
+	// An action to execute before any subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+
+	// The action to execute when no subcommands are specified
+	// Expects a `cli.ActionFunc` but will accept the *deprecated* signature of `func(*cli.Context) {}`
+	// *Note*: support for the deprecated `Action` signature will be removed in a future version
+	Action interface{}
+
+	// Execute this function if the proper command cannot be found
+	CommandNotFound CommandNotFoundFunc
+	// Execute this function if an usage error occurs
+	OnUsageError OnUsageErrorFunc
+	// Compilation date
+	Compiled time.Time
+	// List of all authors who contributed
+	Authors []Author
+	// Copyright of the binary if any
+	Copyright string
+	// Name of Author (Note: Use App.Authors, this is deprecated)
+	Author string
+	// Email of Author (Note: Use App.Authors, this is deprecated)
+	Email string
+	// Writer writer to write output to
+	Writer io.Writer
+	// ErrWriter writes error output
+	ErrWriter io.Writer
+	// Other custom info
+	Metadata map[string]interface{}
+
+	didSetup bool
+}
+
+// Tries to find out when this binary was compiled.
+// Returns the current time if it fails to find it.
+func compileTime() time.Time {
+	info, err := os.Stat(os.Args[0])
+	if err != nil {
+		return time.Now()
+	}
+	return info.ModTime()
+}
+
+// NewApp creates a new cli Application with some reasonable defaults for Name,
+// Usage, Version and Action.
+func NewApp() *App {
+	return &App{
+		Name:         filepath.Base(os.Args[0]),
+		HelpName:     filepath.Base(os.Args[0]),
+		Usage:        "A new cli application",
+		UsageText:    "",
+		Version:      "0.0.0",
+		BashComplete: DefaultAppComplete,
+		Action:       helpCommand.Action,
+		Compiled:     compileTime(),
+		Writer:       os.Stdout,
+	}
+}
+
+// Setup runs initialization code to ensure all data structures are ready for
+// `Run` or inspection prior to `Run`.  It is internally called by `Run`, but
+// will return early if setup has already happened.
+func (a *App) Setup() {
+	if a.didSetup {
+		return
+	}
+
+	a.didSetup = true
+
+	if a.Author != "" || a.Email != "" {
+		a.Authors = append(a.Authors, Author{Name: a.Author, Email: a.Email})
+	}
+
+	newCmds := []Command{}
+	for _, c := range a.Commands {
+		if c.HelpName == "" {
+			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+		}
+		newCmds = append(newCmds, c)
+	}
+	a.Commands = newCmds
+
+	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
+		a.Commands = append(a.Commands, helpCommand)
+		if (HelpFlag != BoolFlag{}) {
+			a.appendFlag(HelpFlag)
+		}
+	}
+
+	if !a.HideVersion {
+		a.appendFlag(VersionFlag)
+	}
+
+	a.categories = CommandCategories{}
+	for _, command := range a.Commands {
+		a.categories = a.categories.AddCommand(command.Category, command)
+	}
+	sort.Sort(a.categories)
+
+	if a.Metadata == nil {
+		a.Metadata = make(map[string]interface{})
+	}
+
+	if a.Writer == nil {
+		a.Writer = os.Stdout
+	}
+}
+
+// Run is the entry point to the cli app. Parses the arguments slice and routes
+// to the proper flag/args combination
+func (a *App) Run(arguments []string) (err error) {
+	a.Setup()
+
+	// handle the completion flag separately from the flagset since
+	// completion could be attempted after a flag, but before its value was put
+	// on the command line. this causes the flagset to interpret the completion
+	// flag name as the value of the flag before it which is undesirable
+	// note that we can only do this because the shell autocomplete function
+	// always appends the completion flag at the end of the command
+	shellComplete, arguments := checkShellCompleteFlag(a, arguments)
+
+	// parse flags
+	set, err := flagSet(a.Name, a.Flags)
+	if err != nil {
+		return err
+	}
+
+	set.SetOutput(ioutil.Discard)
+	err = set.Parse(arguments[1:])
+	nerr := normalizeFlags(a.Flags, set)
+	context := NewContext(a, set, nil)
+	if nerr != nil {
+		fmt.Fprintln(a.Writer, nerr)
+		ShowAppHelp(context)
+		return nerr
+	}
+	context.shellComplete = shellComplete
+
+	if checkCompletions(context) {
+		return nil
+	}
+
+	if err != nil {
+		if a.OnUsageError != nil {
+			err := a.OnUsageError(context, err, false)
+			HandleExitCoder(err)
+			return err
+		}
+		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
+		ShowAppHelp(context)
+		return err
+	}
+
+	if !a.HideHelp && checkHelp(context) {
+		ShowAppHelp(context)
+		return nil
+	}
+
+	if !a.HideVersion && checkVersion(context) {
+		ShowVersion(context)
+		return nil
+	}
+
+	if a.After != nil {
+		defer func() {
+			if afterErr := a.After(context); afterErr != nil {
+				if err != nil {
+					err = NewMultiError(err, afterErr)
+				} else {
+					err = afterErr
+				}
+			}
+		}()
+	}
+
+	if a.Before != nil {
+		beforeErr := a.Before(context)
+		if beforeErr != nil {
+			fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
+			ShowAppHelp(context)
+			HandleExitCoder(beforeErr)
+			err = beforeErr
+			return err
+		}
+	}
+
+	args := context.Args()
+	if args.Present() {
+		name := args.First()
+		c := a.Command(name)
+		if c != nil {
+			return c.Run(context)
+		}
+	}
+
+	if a.Action == nil {
+		a.Action = helpCommand.Action
+	}
+
+	// Run default Action
+	err = HandleAction(a.Action, context)
+
+	HandleExitCoder(err)
+	return err
+}
+
+// RunAndExitOnError calls .Run() and exits non-zero if an error was returned
+//
+// Deprecated: instead you should return an error that fulfills cli.ExitCoder
+// to cli.App.Run. This will cause the application to exit with the given eror
+// code in the cli.ExitCoder
+func (a *App) RunAndExitOnError() {
+	if err := a.Run(os.Args); err != nil {
+		fmt.Fprintln(a.errWriter(), err)
+		OsExiter(1)
+	}
+}
+
+// RunAsSubcommand invokes the subcommand given the context, parses ctx.Args() to
+// generate command-specific flags
+func (a *App) RunAsSubcommand(ctx *Context) (err error) {
+	// append help to commands
+	if len(a.Commands) > 0 {
+		if a.Command(helpCommand.Name) == nil && !a.HideHelp {
+			a.Commands = append(a.Commands, helpCommand)
+			if (HelpFlag != BoolFlag{}) {
+				a.appendFlag(HelpFlag)
+			}
+		}
+	}
+
+	newCmds := []Command{}
+	for _, c := range a.Commands {
+		if c.HelpName == "" {
+			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+		}
+		newCmds = append(newCmds, c)
+	}
+	a.Commands = newCmds
+
+	// parse flags
+	set, err := flagSet(a.Name, a.Flags)
+	if err != nil {
+		return err
+	}
+
+	set.SetOutput(ioutil.Discard)
+	err = set.Parse(ctx.Args().Tail())
+	nerr := normalizeFlags(a.Flags, set)
+	context := NewContext(a, set, ctx)
+
+	if nerr != nil {
+		fmt.Fprintln(a.Writer, nerr)
+		fmt.Fprintln(a.Writer)
+		if len(a.Commands) > 0 {
+			ShowSubcommandHelp(context)
+		} else {
+			ShowCommandHelp(ctx, context.Args().First())
+		}
+		return nerr
+	}
+
+	if checkCompletions(context) {
+		return nil
+	}
+
+	if err != nil {
+		if a.OnUsageError != nil {
+			err = a.OnUsageError(context, err, true)
+			HandleExitCoder(err)
+			return err
+		}
+		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
+		ShowSubcommandHelp(context)
+		return err
+	}
+
+	if len(a.Commands) > 0 {
+		if checkSubcommandHelp(context) {
+			return nil
+		}
+	} else {
+		if checkCommandHelp(ctx, context.Args().First()) {
+			return nil
+		}
+	}
+
+	if a.After != nil {
+		defer func() {
+			afterErr := a.After(context)
+			if afterErr != nil {
+				HandleExitCoder(err)
+				if err != nil {
+					err = NewMultiError(err, afterErr)
+				} else {
+					err = afterErr
+				}
+			}
+		}()
+	}
+
+	if a.Before != nil {
+		beforeErr := a.Before(context)
+		if beforeErr != nil {
+			HandleExitCoder(beforeErr)
+			err = beforeErr
+			return err
+		}
+	}
+
+	args := context.Args()
+	if args.Present() {
+		name := args.First()
+		c := a.Command(name)
+		if c != nil {
+			return c.Run(context)
+		}
+	}
+
+	// Run default Action
+	err = HandleAction(a.Action, context)
+
+	HandleExitCoder(err)
+	return err
+}
+
+// Command returns the named command on App. Returns nil if the command does not exist
+func (a *App) Command(name string) *Command {
+	for _, c := range a.Commands {
+		if c.HasName(name) {
+			return &c
+		}
+	}
+
+	return nil
+}
+
+// Categories returns a slice containing all the categories with the commands they contain
+func (a *App) Categories() CommandCategories {
+	return a.categories
+}
+
+// VisibleCategories returns a slice of categories and commands that are
+// Hidden=false
+func (a *App) VisibleCategories() []*CommandCategory {
+	ret := []*CommandCategory{}
+	for _, category := range a.categories {
+		if visible := func() *CommandCategory {
+			for _, command := range category.Commands {
+				if !command.Hidden {
+					return category
+				}
+			}
+			return nil
+		}(); visible != nil {
+			ret = append(ret, visible)
+		}
+	}
+	return ret
+}
+
+// VisibleCommands returns a slice of the Commands with Hidden=false
+func (a *App) VisibleCommands() []Command {
+	ret := []Command{}
+	for _, command := range a.Commands {
+		if !command.Hidden {
+			ret = append(ret, command)
+		}
+	}
+	return ret
+}
+
+// VisibleFlags returns a slice of the Flags with Hidden=false
+func (a *App) VisibleFlags() []Flag {
+	return visibleFlags(a.Flags)
+}
+
+func (a *App) hasFlag(flag Flag) bool {
+	for _, f := range a.Flags {
+		if flag == f {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (a *App) errWriter() io.Writer {
+
+	// When the app ErrWriter is nil use the package level one.
+	if a.ErrWriter == nil {
+		return ErrWriter
+	}
+
+	return a.ErrWriter
+}
+
+func (a *App) appendFlag(flag Flag) {
+	if !a.hasFlag(flag) {
+		a.Flags = append(a.Flags, flag)
+	}
+}
+
+// Author represents someone who has contributed to a cli project.
+type Author struct {
+	Name  string // The Authors name
+	Email string // The Authors email
+}
+
+// String makes Author comply to the Stringer interface, to allow an easy print in the templating process
+func (a Author) String() string {
+	e := ""
+	if a.Email != "" {
+		e = " <" + a.Email + ">"
+	}
+
+	return fmt.Sprintf("%v%v", a.Name, e)
+}
+
+// HandleAction attempts to figure out which Action signature was used.  If
+// it's an ActionFunc or a func with the legacy signature for Action, the func
+// is run!
+func HandleAction(action interface{}, context *Context) (err error) {
+	if a, ok := action.(ActionFunc); ok {
+		return a(context)
+	} else if a, ok := action.(func(*Context) error); ok {
+		return a(context)
+	} else if a, ok := action.(func(*Context)); ok { // deprecated function signature
+		a(context)
+		return nil
+	} else {
+		return errInvalidActionType
+	}
+}

--- a/vendor/github.com/urfave/cli/app_test.go
+++ b/vendor/github.com/urfave/cli/app_test.go
@@ -1,0 +1,1685 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+var (
+	lastExitCode = 0
+	fakeOsExiter = func(rc int) {
+		lastExitCode = rc
+	}
+	fakeErrWriter = &bytes.Buffer{}
+)
+
+func init() {
+	OsExiter = fakeOsExiter
+	ErrWriter = fakeErrWriter
+}
+
+type opCounts struct {
+	Total, BashComplete, OnUsageError, Before, CommandNotFound, Action, After, SubCommand int
+}
+
+func ExampleApp_Run() {
+	// set args for examples sake
+	os.Args = []string{"greet", "--name", "Jeremy"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.Flags = []Flag{
+		StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},
+	}
+	app.Action = func(c *Context) error {
+		fmt.Printf("Hello %v\n", c.String("name"))
+		return nil
+	}
+	app.UsageText = "app [first_arg] [second_arg]"
+	app.Author = "Harrison"
+	app.Email = "harrison@lolwut.com"
+	app.Authors = []Author{{Name: "Oliver Allen", Email: "oliver@toyshop.com"}}
+	app.Run(os.Args)
+	// Output:
+	// Hello Jeremy
+}
+
+func ExampleApp_Run_subcommand() {
+	// set args for examples sake
+	os.Args = []string{"say", "hi", "english", "--name", "Jeremy"}
+	app := NewApp()
+	app.Name = "say"
+	app.Commands = []Command{
+		{
+			Name:        "hello",
+			Aliases:     []string{"hi"},
+			Usage:       "use it to see a description",
+			Description: "This is how we describe hello the function",
+			Subcommands: []Command{
+				{
+					Name:        "english",
+					Aliases:     []string{"en"},
+					Usage:       "sends a greeting in english",
+					Description: "greets someone in english",
+					Flags: []Flag{
+						StringFlag{
+							Name:  "name",
+							Value: "Bob",
+							Usage: "Name of the person to greet",
+						},
+					},
+					Action: func(c *Context) error {
+						fmt.Println("Hello,", c.String("name"))
+						return nil
+					},
+				},
+			},
+		},
+	}
+
+	app.Run(os.Args)
+	// Output:
+	// Hello, Jeremy
+}
+
+func ExampleApp_Run_appHelp() {
+	// set args for examples sake
+	os.Args = []string{"greet", "help"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.Version = "0.1.0"
+	app.Description = "This is how we describe greet the app"
+	app.Authors = []Author{
+		{Name: "Harrison", Email: "harrison@lolwut.com"},
+		{Name: "Oliver Allen", Email: "oliver@toyshop.com"},
+	}
+	app.Flags = []Flag{
+		StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},
+	}
+	app.Commands = []Command{
+		{
+			Name:        "describeit",
+			Aliases:     []string{"d"},
+			Usage:       "use it to see a description",
+			Description: "This is how we describe describeit the function",
+			Action: func(c *Context) error {
+				fmt.Printf("i like to describe things")
+				return nil
+			},
+		},
+	}
+	app.Run(os.Args)
+	// Output:
+	// NAME:
+	//    greet - A new cli application
+	//
+	// USAGE:
+	//    greet [global options] command [command options] [arguments...]
+	//
+	// VERSION:
+	//    0.1.0
+	//
+	// DESCRIPTION:
+	//    This is how we describe greet the app
+	//
+	// AUTHORS:
+	//    Harrison <harrison@lolwut.com>
+	//    Oliver Allen <oliver@toyshop.com>
+	//
+	// COMMANDS:
+	//      describeit, d  use it to see a description
+	//      help, h        Shows a list of commands or help for one command
+	//
+	// GLOBAL OPTIONS:
+	//    --name value   a name to say (default: "bob")
+	//    --help, -h     show help
+	//    --version, -v  print the version
+}
+
+func ExampleApp_Run_commandHelp() {
+	// set args for examples sake
+	os.Args = []string{"greet", "h", "describeit"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.Flags = []Flag{
+		StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},
+	}
+	app.Commands = []Command{
+		{
+			Name:        "describeit",
+			Aliases:     []string{"d"},
+			Usage:       "use it to see a description",
+			Description: "This is how we describe describeit the function",
+			Action: func(c *Context) error {
+				fmt.Printf("i like to describe things")
+				return nil
+			},
+		},
+	}
+	app.Run(os.Args)
+	// Output:
+	// NAME:
+	//    greet describeit - use it to see a description
+	//
+	// USAGE:
+	//    greet describeit [arguments...]
+	//
+	// DESCRIPTION:
+	//    This is how we describe describeit the function
+}
+
+func ExampleApp_Run_noAction() {
+	app := App{}
+	app.Name = "greet"
+	app.Run([]string{"greet"})
+	// Output:
+	// NAME:
+	//    greet
+	//
+	// USAGE:
+	//     [global options] command [command options] [arguments...]
+	//
+	// COMMANDS:
+	//      help, h  Shows a list of commands or help for one command
+	//
+	// GLOBAL OPTIONS:
+	//    --help, -h     show help
+	//    --version, -v  print the version
+}
+
+func ExampleApp_Run_subcommandNoAction() {
+	app := App{}
+	app.Name = "greet"
+	app.Commands = []Command{
+		{
+			Name:        "describeit",
+			Aliases:     []string{"d"},
+			Usage:       "use it to see a description",
+			Description: "This is how we describe describeit the function",
+		},
+	}
+	app.Run([]string{"greet", "describeit"})
+	// Output:
+	// NAME:
+	//     describeit - use it to see a description
+	//
+	// USAGE:
+	//     describeit [arguments...]
+	//
+	// DESCRIPTION:
+	//    This is how we describe describeit the function
+
+}
+
+func ExampleApp_Run_bashComplete() {
+	// set args for examples sake
+	os.Args = []string{"greet", "--generate-bash-completion"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.EnableBashCompletion = true
+	app.Commands = []Command{
+		{
+			Name:        "describeit",
+			Aliases:     []string{"d"},
+			Usage:       "use it to see a description",
+			Description: "This is how we describe describeit the function",
+			Action: func(c *Context) error {
+				fmt.Printf("i like to describe things")
+				return nil
+			},
+		}, {
+			Name:        "next",
+			Usage:       "next example",
+			Description: "more stuff to see when generating bash completion",
+			Action: func(c *Context) error {
+				fmt.Printf("the next example")
+				return nil
+			},
+		},
+	}
+
+	app.Run(os.Args)
+	// Output:
+	// describeit
+	// d
+	// next
+	// help
+	// h
+}
+
+func TestApp_Run(t *testing.T) {
+	s := ""
+
+	app := NewApp()
+	app.Action = func(c *Context) error {
+		s = s + c.Args().First()
+		return nil
+	}
+
+	err := app.Run([]string{"command", "foo"})
+	expect(t, err, nil)
+	err = app.Run([]string{"command", "bar"})
+	expect(t, err, nil)
+	expect(t, s, "foobar")
+}
+
+var commandAppTests = []struct {
+	name     string
+	expected bool
+}{
+	{"foobar", true},
+	{"batbaz", true},
+	{"b", true},
+	{"f", true},
+	{"bat", false},
+	{"nothing", false},
+}
+
+func TestApp_Command(t *testing.T) {
+	app := NewApp()
+	fooCommand := Command{Name: "foobar", Aliases: []string{"f"}}
+	batCommand := Command{Name: "batbaz", Aliases: []string{"b"}}
+	app.Commands = []Command{
+		fooCommand,
+		batCommand,
+	}
+
+	for _, test := range commandAppTests {
+		expect(t, app.Command(test.name) != nil, test.expected)
+	}
+}
+
+func TestApp_Setup_defaultsWriter(t *testing.T) {
+	app := &App{}
+	app.Setup()
+	expect(t, app.Writer, os.Stdout)
+}
+
+func TestApp_CommandWithArgBeforeFlags(t *testing.T) {
+	var parsedOption, firstArg string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			StringFlag{Name: "option", Value: "", Usage: "some option"},
+		},
+		Action: func(c *Context) error {
+			parsedOption = c.String("option")
+			firstArg = c.Args().First()
+			return nil
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "--option", "my-option"})
+
+	expect(t, parsedOption, "my-option")
+	expect(t, firstArg, "my-arg")
+}
+
+func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
+	var context *Context
+
+	a := NewApp()
+	a.Commands = []Command{
+		{
+			Name: "foo",
+			Action: func(c *Context) error {
+				context = c
+				return nil
+			},
+			Flags: []Flag{
+				StringFlag{
+					Name:  "lang",
+					Value: "english",
+					Usage: "language for the greeting",
+				},
+			},
+			Before: func(_ *Context) error { return nil },
+		},
+	}
+	a.Run([]string{"", "foo", "--lang", "spanish", "abcd"})
+
+	expect(t, context.Args().Get(0), "abcd")
+	expect(t, context.String("lang"), "spanish")
+}
+
+func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			StringFlag{Name: "--foo"},
+		},
+		Writer: bytes.NewBufferString(""),
+	}
+
+	set := flag.NewFlagSet("", flag.ContinueOnError)
+	set.Parse([]string{"", "---foo"})
+	c := &Context{flagSet: set}
+
+	err := a.RunAsSubcommand(c)
+
+	expect(t, err, errors.New("bad flag syntax: ---foo"))
+}
+
+func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {
+	var parsedOption string
+	var args []string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			StringFlag{Name: "option", Value: "", Usage: "some option"},
+		},
+		Action: func(c *Context) error {
+			parsedOption = c.String("option")
+			args = c.Args()
+			return nil
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "--option", "my-option", "--", "--notARealFlag"})
+
+	expect(t, parsedOption, "my-option")
+	expect(t, args[0], "my-arg")
+	expect(t, args[1], "--")
+	expect(t, args[2], "--notARealFlag")
+}
+
+func TestApp_CommandWithDash(t *testing.T) {
+	var args []string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Action: func(c *Context) error {
+			args = c.Args()
+			return nil
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "-"})
+
+	expect(t, args[0], "my-arg")
+	expect(t, args[1], "-")
+}
+
+func TestApp_CommandWithNoFlagBeforeTerminator(t *testing.T) {
+	var args []string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Action: func(c *Context) error {
+			args = c.Args()
+			return nil
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "--", "notAFlagAtAll"})
+
+	expect(t, args[0], "my-arg")
+	expect(t, args[1], "--")
+	expect(t, args[2], "notAFlagAtAll")
+}
+
+func TestApp_VisibleCommands(t *testing.T) {
+	app := NewApp()
+	app.Commands = []Command{
+		{
+			Name:     "frob",
+			HelpName: "foo frob",
+			Action:   func(_ *Context) error { return nil },
+		},
+		{
+			Name:     "frib",
+			HelpName: "foo frib",
+			Hidden:   true,
+			Action:   func(_ *Context) error { return nil },
+		},
+	}
+
+	app.Setup()
+	expected := []Command{
+		app.Commands[0],
+		app.Commands[2], // help
+	}
+	actual := app.VisibleCommands()
+	expect(t, len(expected), len(actual))
+	for i, actualCommand := range actual {
+		expectedCommand := expected[i]
+
+		if expectedCommand.Action != nil {
+			// comparing func addresses is OK!
+			expect(t, fmt.Sprintf("%p", expectedCommand.Action), fmt.Sprintf("%p", actualCommand.Action))
+		}
+
+		// nil out funcs, as they cannot be compared
+		// (https://github.com/golang/go/issues/8554)
+		expectedCommand.Action = nil
+		actualCommand.Action = nil
+
+		if !reflect.DeepEqual(expectedCommand, actualCommand) {
+			t.Errorf("expected\n%#v\n!=\n%#v", expectedCommand, actualCommand)
+		}
+	}
+}
+
+func TestApp_Float64Flag(t *testing.T) {
+	var meters float64
+
+	app := NewApp()
+	app.Flags = []Flag{
+		Float64Flag{Name: "height", Value: 1.5, Usage: "Set the height, in meters"},
+	}
+	app.Action = func(c *Context) error {
+		meters = c.Float64("height")
+		return nil
+	}
+
+	app.Run([]string{"", "--height", "1.93"})
+	expect(t, meters, 1.93)
+}
+
+func TestApp_ParseSliceFlags(t *testing.T) {
+	var parsedOption, firstArg string
+	var parsedIntSlice []int
+	var parsedStringSlice []string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			IntSliceFlag{Name: "p", Value: &IntSlice{}, Usage: "set one or more ip addr"},
+			StringSliceFlag{Name: "ip", Value: &StringSlice{}, Usage: "set one or more ports to open"},
+		},
+		Action: func(c *Context) error {
+			parsedIntSlice = c.IntSlice("p")
+			parsedStringSlice = c.StringSlice("ip")
+			parsedOption = c.String("option")
+			firstArg = c.Args().First()
+			return nil
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "-p", "22", "-p", "80", "-ip", "8.8.8.8", "-ip", "8.8.4.4"})
+
+	IntsEquals := func(a, b []int) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i, v := range a {
+			if v != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	StrsEquals := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i, v := range a {
+			if v != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	var expectedIntSlice = []int{22, 80}
+	var expectedStringSlice = []string{"8.8.8.8", "8.8.4.4"}
+
+	if !IntsEquals(parsedIntSlice, expectedIntSlice) {
+		t.Errorf("%v does not match %v", parsedIntSlice, expectedIntSlice)
+	}
+
+	if !StrsEquals(parsedStringSlice, expectedStringSlice) {
+		t.Errorf("%v does not match %v", parsedStringSlice, expectedStringSlice)
+	}
+}
+
+func TestApp_ParseSliceFlagsWithMissingValue(t *testing.T) {
+	var parsedIntSlice []int
+	var parsedStringSlice []string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			IntSliceFlag{Name: "a", Usage: "set numbers"},
+			StringSliceFlag{Name: "str", Usage: "set strings"},
+		},
+		Action: func(c *Context) error {
+			parsedIntSlice = c.IntSlice("a")
+			parsedStringSlice = c.StringSlice("str")
+			return nil
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "-a", "2", "-str", "A"})
+
+	var expectedIntSlice = []int{2}
+	var expectedStringSlice = []string{"A"}
+
+	if parsedIntSlice[0] != expectedIntSlice[0] {
+		t.Errorf("%v does not match %v", parsedIntSlice[0], expectedIntSlice[0])
+	}
+
+	if parsedStringSlice[0] != expectedStringSlice[0] {
+		t.Errorf("%v does not match %v", parsedIntSlice[0], expectedIntSlice[0])
+	}
+}
+
+func TestApp_DefaultStdout(t *testing.T) {
+	app := NewApp()
+
+	if app.Writer != os.Stdout {
+		t.Error("Default output writer not set.")
+	}
+}
+
+type mockWriter struct {
+	written []byte
+}
+
+func (fw *mockWriter) Write(p []byte) (n int, err error) {
+	if fw.written == nil {
+		fw.written = p
+	} else {
+		fw.written = append(fw.written, p...)
+	}
+
+	return len(p), nil
+}
+
+func (fw *mockWriter) GetWritten() (b []byte) {
+	return fw.written
+}
+
+func TestApp_SetStdout(t *testing.T) {
+	w := &mockWriter{}
+
+	app := NewApp()
+	app.Name = "test"
+	app.Writer = w
+
+	err := app.Run([]string{"help"})
+
+	if err != nil {
+		t.Fatalf("Run error: %s", err)
+	}
+
+	if len(w.written) == 0 {
+		t.Error("App did not write output to desired writer.")
+	}
+}
+
+func TestApp_BeforeFunc(t *testing.T) {
+	counts := &opCounts{}
+	beforeError := fmt.Errorf("fail")
+	var err error
+
+	app := NewApp()
+
+	app.Before = func(c *Context) error {
+		counts.Total++
+		counts.Before = counts.Total
+		s := c.String("opt")
+		if s == "fail" {
+			return beforeError
+		}
+
+		return nil
+	}
+
+	app.Commands = []Command{
+		{
+			Name: "sub",
+			Action: func(c *Context) error {
+				counts.Total++
+				counts.SubCommand = counts.Total
+				return nil
+			},
+		},
+	}
+
+	app.Flags = []Flag{
+		StringFlag{Name: "opt"},
+	}
+
+	// run with the Before() func succeeding
+	err = app.Run([]string{"command", "--opt", "succeed", "sub"})
+
+	if err != nil {
+		t.Fatalf("Run error: %s", err)
+	}
+
+	if counts.Before != 1 {
+		t.Errorf("Before() not executed when expected")
+	}
+
+	if counts.SubCommand != 2 {
+		t.Errorf("Subcommand not executed when expected")
+	}
+
+	// reset
+	counts = &opCounts{}
+
+	// run with the Before() func failing
+	err = app.Run([]string{"command", "--opt", "fail", "sub"})
+
+	// should be the same error produced by the Before func
+	if err != beforeError {
+		t.Errorf("Run error expected, but not received")
+	}
+
+	if counts.Before != 1 {
+		t.Errorf("Before() not executed when expected")
+	}
+
+	if counts.SubCommand != 0 {
+		t.Errorf("Subcommand executed when NOT expected")
+	}
+
+	// reset
+	counts = &opCounts{}
+
+	afterError := errors.New("fail again")
+	app.After = func(_ *Context) error {
+		return afterError
+	}
+
+	// run with the Before() func failing, wrapped by After()
+	err = app.Run([]string{"command", "--opt", "fail", "sub"})
+
+	// should be the same error produced by the Before func
+	if _, ok := err.(MultiError); !ok {
+		t.Errorf("MultiError expected, but not received")
+	}
+
+	if counts.Before != 1 {
+		t.Errorf("Before() not executed when expected")
+	}
+
+	if counts.SubCommand != 0 {
+		t.Errorf("Subcommand executed when NOT expected")
+	}
+}
+
+func TestApp_AfterFunc(t *testing.T) {
+	counts := &opCounts{}
+	afterError := fmt.Errorf("fail")
+	var err error
+
+	app := NewApp()
+
+	app.After = func(c *Context) error {
+		counts.Total++
+		counts.After = counts.Total
+		s := c.String("opt")
+		if s == "fail" {
+			return afterError
+		}
+
+		return nil
+	}
+
+	app.Commands = []Command{
+		{
+			Name: "sub",
+			Action: func(c *Context) error {
+				counts.Total++
+				counts.SubCommand = counts.Total
+				return nil
+			},
+		},
+	}
+
+	app.Flags = []Flag{
+		StringFlag{Name: "opt"},
+	}
+
+	// run with the After() func succeeding
+	err = app.Run([]string{"command", "--opt", "succeed", "sub"})
+
+	if err != nil {
+		t.Fatalf("Run error: %s", err)
+	}
+
+	if counts.After != 2 {
+		t.Errorf("After() not executed when expected")
+	}
+
+	if counts.SubCommand != 1 {
+		t.Errorf("Subcommand not executed when expected")
+	}
+
+	// reset
+	counts = &opCounts{}
+
+	// run with the Before() func failing
+	err = app.Run([]string{"command", "--opt", "fail", "sub"})
+
+	// should be the same error produced by the Before func
+	if err != afterError {
+		t.Errorf("Run error expected, but not received")
+	}
+
+	if counts.After != 2 {
+		t.Errorf("After() not executed when expected")
+	}
+
+	if counts.SubCommand != 1 {
+		t.Errorf("Subcommand not executed when expected")
+	}
+}
+
+func TestAppNoHelpFlag(t *testing.T) {
+	oldFlag := HelpFlag
+	defer func() {
+		HelpFlag = oldFlag
+	}()
+
+	HelpFlag = BoolFlag{}
+
+	app := NewApp()
+	app.Writer = ioutil.Discard
+	err := app.Run([]string{"test", "-h"})
+
+	if err != flag.ErrHelp {
+		t.Errorf("expected error about missing help flag, but got: %s (%T)", err, err)
+	}
+}
+
+func TestAppHelpPrinter(t *testing.T) {
+	oldPrinter := HelpPrinter
+	defer func() {
+		HelpPrinter = oldPrinter
+	}()
+
+	var wasCalled = false
+	HelpPrinter = func(w io.Writer, template string, data interface{}) {
+		wasCalled = true
+	}
+
+	app := NewApp()
+	app.Run([]string{"-h"})
+
+	if wasCalled == false {
+		t.Errorf("Help printer expected to be called, but was not")
+	}
+}
+
+func TestApp_VersionPrinter(t *testing.T) {
+	oldPrinter := VersionPrinter
+	defer func() {
+		VersionPrinter = oldPrinter
+	}()
+
+	var wasCalled = false
+	VersionPrinter = func(c *Context) {
+		wasCalled = true
+	}
+
+	app := NewApp()
+	ctx := NewContext(app, nil, nil)
+	ShowVersion(ctx)
+
+	if wasCalled == false {
+		t.Errorf("Version printer expected to be called, but was not")
+	}
+}
+
+func TestApp_CommandNotFound(t *testing.T) {
+	counts := &opCounts{}
+	app := NewApp()
+
+	app.CommandNotFound = func(c *Context, command string) {
+		counts.Total++
+		counts.CommandNotFound = counts.Total
+	}
+
+	app.Commands = []Command{
+		{
+			Name: "bar",
+			Action: func(c *Context) error {
+				counts.Total++
+				counts.SubCommand = counts.Total
+				return nil
+			},
+		},
+	}
+
+	app.Run([]string{"command", "foo"})
+
+	expect(t, counts.CommandNotFound, 1)
+	expect(t, counts.SubCommand, 0)
+	expect(t, counts.Total, 1)
+}
+
+func TestApp_OrderOfOperations(t *testing.T) {
+	counts := &opCounts{}
+
+	resetCounts := func() { counts = &opCounts{} }
+
+	app := NewApp()
+	app.EnableBashCompletion = true
+	app.BashComplete = func(c *Context) {
+		counts.Total++
+		counts.BashComplete = counts.Total
+	}
+
+	app.OnUsageError = func(c *Context, err error, isSubcommand bool) error {
+		counts.Total++
+		counts.OnUsageError = counts.Total
+		return errors.New("hay OnUsageError")
+	}
+
+	beforeNoError := func(c *Context) error {
+		counts.Total++
+		counts.Before = counts.Total
+		return nil
+	}
+
+	beforeError := func(c *Context) error {
+		counts.Total++
+		counts.Before = counts.Total
+		return errors.New("hay Before")
+	}
+
+	app.Before = beforeNoError
+	app.CommandNotFound = func(c *Context, command string) {
+		counts.Total++
+		counts.CommandNotFound = counts.Total
+	}
+
+	afterNoError := func(c *Context) error {
+		counts.Total++
+		counts.After = counts.Total
+		return nil
+	}
+
+	afterError := func(c *Context) error {
+		counts.Total++
+		counts.After = counts.Total
+		return errors.New("hay After")
+	}
+
+	app.After = afterNoError
+	app.Commands = []Command{
+		{
+			Name: "bar",
+			Action: func(c *Context) error {
+				counts.Total++
+				counts.SubCommand = counts.Total
+				return nil
+			},
+		},
+	}
+
+	app.Action = func(c *Context) error {
+		counts.Total++
+		counts.Action = counts.Total
+		return nil
+	}
+
+	_ = app.Run([]string{"command", "--nope"})
+	expect(t, counts.OnUsageError, 1)
+	expect(t, counts.Total, 1)
+
+	resetCounts()
+
+	_ = app.Run([]string{"command", "--generate-bash-completion"})
+	expect(t, counts.BashComplete, 1)
+	expect(t, counts.Total, 1)
+
+	resetCounts()
+
+	oldOnUsageError := app.OnUsageError
+	app.OnUsageError = nil
+	_ = app.Run([]string{"command", "--nope"})
+	expect(t, counts.Total, 0)
+	app.OnUsageError = oldOnUsageError
+
+	resetCounts()
+
+	_ = app.Run([]string{"command", "foo"})
+	expect(t, counts.OnUsageError, 0)
+	expect(t, counts.Before, 1)
+	expect(t, counts.CommandNotFound, 0)
+	expect(t, counts.Action, 2)
+	expect(t, counts.After, 3)
+	expect(t, counts.Total, 3)
+
+	resetCounts()
+
+	app.Before = beforeError
+	_ = app.Run([]string{"command", "bar"})
+	expect(t, counts.OnUsageError, 0)
+	expect(t, counts.Before, 1)
+	expect(t, counts.After, 2)
+	expect(t, counts.Total, 2)
+	app.Before = beforeNoError
+
+	resetCounts()
+
+	app.After = nil
+	_ = app.Run([]string{"command", "bar"})
+	expect(t, counts.OnUsageError, 0)
+	expect(t, counts.Before, 1)
+	expect(t, counts.SubCommand, 2)
+	expect(t, counts.Total, 2)
+	app.After = afterNoError
+
+	resetCounts()
+
+	app.After = afterError
+	err := app.Run([]string{"command", "bar"})
+	if err == nil {
+		t.Fatalf("expected a non-nil error")
+	}
+	expect(t, counts.OnUsageError, 0)
+	expect(t, counts.Before, 1)
+	expect(t, counts.SubCommand, 2)
+	expect(t, counts.After, 3)
+	expect(t, counts.Total, 3)
+	app.After = afterNoError
+
+	resetCounts()
+
+	oldCommands := app.Commands
+	app.Commands = nil
+	_ = app.Run([]string{"command"})
+	expect(t, counts.OnUsageError, 0)
+	expect(t, counts.Before, 1)
+	expect(t, counts.Action, 2)
+	expect(t, counts.After, 3)
+	expect(t, counts.Total, 3)
+	app.Commands = oldCommands
+}
+
+func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
+	var subcommandHelpTopics = [][]string{
+		{"command", "foo", "--help"},
+		{"command", "foo", "-h"},
+		{"command", "foo", "help"},
+	}
+
+	for _, flagSet := range subcommandHelpTopics {
+		t.Logf("==> checking with flags %v", flagSet)
+
+		app := NewApp()
+		buf := new(bytes.Buffer)
+		app.Writer = buf
+
+		subCmdBar := Command{
+			Name:  "bar",
+			Usage: "does bar things",
+		}
+		subCmdBaz := Command{
+			Name:  "baz",
+			Usage: "does baz things",
+		}
+		cmd := Command{
+			Name:        "foo",
+			Description: "descriptive wall of text about how it does foo things",
+			Subcommands: []Command{subCmdBar, subCmdBaz},
+			Action:      func(c *Context) error { return nil },
+		}
+
+		app.Commands = []Command{cmd}
+		err := app.Run(flagSet)
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		output := buf.String()
+		t.Logf("output: %q\n", buf.Bytes())
+
+		if strings.Contains(output, "No help topic for") {
+			t.Errorf("expect a help topic, got none: \n%q", output)
+		}
+
+		for _, shouldContain := range []string{
+			cmd.Name, cmd.Description,
+			subCmdBar.Name, subCmdBar.Usage,
+			subCmdBaz.Name, subCmdBaz.Usage,
+		} {
+			if !strings.Contains(output, shouldContain) {
+				t.Errorf("want help to contain %q, did not: \n%q", shouldContain, output)
+			}
+		}
+	}
+}
+
+func TestApp_Run_SubcommandFullPath(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "command"
+	subCmd := Command{
+		Name:  "bar",
+		Usage: "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "command foo bar - does bar things") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+	if !strings.Contains(output, "command foo bar [arguments...]") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_SubcommandHelpName(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "command"
+	subCmd := Command{
+		Name:     "bar",
+		HelpName: "custom",
+		Usage:    "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "custom - does bar things") {
+		t.Errorf("expected HelpName for subcommand: %s", output)
+	}
+	if !strings.Contains(output, "custom [arguments...]") {
+		t.Errorf("expected HelpName to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_CommandHelpName(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "command"
+	subCmd := Command{
+		Name:  "bar",
+		Usage: "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		HelpName:    "custom",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "command foo bar - does bar things") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+	if !strings.Contains(output, "command foo bar [arguments...]") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_CommandSubcommandHelpName(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "base"
+	subCmd := Command{
+		Name:     "bar",
+		HelpName: "custom",
+		Usage:    "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "base foo - foo commands") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+	if !strings.Contains(output, "base foo command [command options] [arguments...]") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_Help(t *testing.T) {
+	var helpArguments = [][]string{{"boom", "--help"}, {"boom", "-h"}, {"boom", "help"}}
+
+	for _, args := range helpArguments {
+		buf := new(bytes.Buffer)
+
+		t.Logf("==> checking with arguments %v", args)
+
+		app := NewApp()
+		app.Name = "boom"
+		app.Usage = "make an explosive entrance"
+		app.Writer = buf
+		app.Action = func(c *Context) error {
+			buf.WriteString("boom I say!")
+			return nil
+		}
+
+		err := app.Run(args)
+		if err != nil {
+			t.Error(err)
+		}
+
+		output := buf.String()
+		t.Logf("output: %q\n", buf.Bytes())
+
+		if !strings.Contains(output, "boom - make an explosive entrance") {
+			t.Errorf("want help to contain %q, did not: \n%q", "boom - make an explosive entrance", output)
+		}
+	}
+}
+
+func TestApp_Run_Version(t *testing.T) {
+	var versionArguments = [][]string{{"boom", "--version"}, {"boom", "-v"}}
+
+	for _, args := range versionArguments {
+		buf := new(bytes.Buffer)
+
+		t.Logf("==> checking with arguments %v", args)
+
+		app := NewApp()
+		app.Name = "boom"
+		app.Usage = "make an explosive entrance"
+		app.Version = "0.1.0"
+		app.Writer = buf
+		app.Action = func(c *Context) error {
+			buf.WriteString("boom I say!")
+			return nil
+		}
+
+		err := app.Run(args)
+		if err != nil {
+			t.Error(err)
+		}
+
+		output := buf.String()
+		t.Logf("output: %q\n", buf.Bytes())
+
+		if !strings.Contains(output, "0.1.0") {
+			t.Errorf("want version to contain %q, did not: \n%q", "0.1.0", output)
+		}
+	}
+}
+
+func TestApp_Run_Categories(t *testing.T) {
+	app := NewApp()
+	app.Name = "categories"
+	app.HideHelp = true
+	app.Commands = []Command{
+		{
+			Name:     "command1",
+			Category: "1",
+		},
+		{
+			Name:     "command2",
+			Category: "1",
+		},
+		{
+			Name:     "command3",
+			Category: "2",
+		},
+	}
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+
+	app.Run([]string{"categories"})
+
+	expect := CommandCategories{
+		&CommandCategory{
+			Name: "1",
+			Commands: []Command{
+				app.Commands[0],
+				app.Commands[1],
+			},
+		},
+		&CommandCategory{
+			Name: "2",
+			Commands: []Command{
+				app.Commands[2],
+			},
+		},
+	}
+	if !reflect.DeepEqual(app.Categories(), expect) {
+		t.Fatalf("expected categories %#v, to equal %#v", app.Categories(), expect)
+	}
+
+	output := buf.String()
+	t.Logf("output: %q\n", buf.Bytes())
+
+	if !strings.Contains(output, "1:\n     command1") {
+		t.Errorf("want buffer to include category %q, did not: \n%q", "1:\n     command1", output)
+	}
+}
+
+func TestApp_VisibleCategories(t *testing.T) {
+	app := NewApp()
+	app.Name = "visible-categories"
+	app.HideHelp = true
+	app.Commands = []Command{
+		{
+			Name:     "command1",
+			Category: "1",
+			HelpName: "foo command1",
+			Hidden:   true,
+		},
+		{
+			Name:     "command2",
+			Category: "2",
+			HelpName: "foo command2",
+		},
+		{
+			Name:     "command3",
+			Category: "3",
+			HelpName: "foo command3",
+		},
+	}
+
+	expected := []*CommandCategory{
+		{
+			Name: "2",
+			Commands: []Command{
+				app.Commands[1],
+			},
+		},
+		{
+			Name: "3",
+			Commands: []Command{
+				app.Commands[2],
+			},
+		},
+	}
+
+	app.Setup()
+	expect(t, expected, app.VisibleCategories())
+
+	app = NewApp()
+	app.Name = "visible-categories"
+	app.HideHelp = true
+	app.Commands = []Command{
+		{
+			Name:     "command1",
+			Category: "1",
+			HelpName: "foo command1",
+			Hidden:   true,
+		},
+		{
+			Name:     "command2",
+			Category: "2",
+			HelpName: "foo command2",
+			Hidden:   true,
+		},
+		{
+			Name:     "command3",
+			Category: "3",
+			HelpName: "foo command3",
+		},
+	}
+
+	expected = []*CommandCategory{
+		{
+			Name: "3",
+			Commands: []Command{
+				app.Commands[2],
+			},
+		},
+	}
+
+	app.Setup()
+	expect(t, expected, app.VisibleCategories())
+
+	app = NewApp()
+	app.Name = "visible-categories"
+	app.HideHelp = true
+	app.Commands = []Command{
+		{
+			Name:     "command1",
+			Category: "1",
+			HelpName: "foo command1",
+			Hidden:   true,
+		},
+		{
+			Name:     "command2",
+			Category: "2",
+			HelpName: "foo command2",
+			Hidden:   true,
+		},
+		{
+			Name:     "command3",
+			Category: "3",
+			HelpName: "foo command3",
+			Hidden:   true,
+		},
+	}
+
+	expected = []*CommandCategory{}
+
+	app.Setup()
+	expect(t, expected, app.VisibleCategories())
+}
+
+func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
+	app := NewApp()
+	app.Action = func(c *Context) error { return nil }
+	app.Before = func(c *Context) error { return fmt.Errorf("before error") }
+	app.After = func(c *Context) error { return fmt.Errorf("after error") }
+
+	err := app.Run([]string{"foo"})
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	if !strings.Contains(err.Error(), "before error") {
+		t.Errorf("expected text of error from Before method, but got none in \"%v\"", err)
+	}
+	if !strings.Contains(err.Error(), "after error") {
+		t.Errorf("expected text of error from After method, but got none in \"%v\"", err)
+	}
+}
+
+func TestApp_Run_SubcommandDoesNotOverwriteErrorFromBefore(t *testing.T) {
+	app := NewApp()
+	app.Commands = []Command{
+		{
+			Subcommands: []Command{
+				{
+					Name: "sub",
+				},
+			},
+			Name:   "bar",
+			Before: func(c *Context) error { return fmt.Errorf("before error") },
+			After:  func(c *Context) error { return fmt.Errorf("after error") },
+		},
+	}
+
+	err := app.Run([]string{"foo", "bar"})
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	if !strings.Contains(err.Error(), "before error") {
+		t.Errorf("expected text of error from Before method, but got none in \"%v\"", err)
+	}
+	if !strings.Contains(err.Error(), "after error") {
+		t.Errorf("expected text of error from After method, but got none in \"%v\"", err)
+	}
+}
+
+func TestApp_OnUsageError_WithWrongFlagValue(t *testing.T) {
+	app := NewApp()
+	app.Flags = []Flag{
+		IntFlag{Name: "flag"},
+	}
+	app.OnUsageError = func(c *Context, err error, isSubcommand bool) error {
+		if isSubcommand {
+			t.Errorf("Expect no subcommand")
+		}
+		if !strings.HasPrefix(err.Error(), "invalid value \"wrong\"") {
+			t.Errorf("Expect an invalid value error, but got \"%v\"", err)
+		}
+		return errors.New("intercepted: " + err.Error())
+	}
+	app.Commands = []Command{
+		{
+			Name: "bar",
+		},
+	}
+
+	err := app.Run([]string{"foo", "--flag=wrong"})
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	if !strings.HasPrefix(err.Error(), "intercepted: invalid value") {
+		t.Errorf("Expect an intercepted error, but got \"%v\"", err)
+	}
+}
+
+func TestApp_OnUsageError_WithWrongFlagValue_ForSubcommand(t *testing.T) {
+	app := NewApp()
+	app.Flags = []Flag{
+		IntFlag{Name: "flag"},
+	}
+	app.OnUsageError = func(c *Context, err error, isSubcommand bool) error {
+		if isSubcommand {
+			t.Errorf("Expect subcommand")
+		}
+		if !strings.HasPrefix(err.Error(), "invalid value \"wrong\"") {
+			t.Errorf("Expect an invalid value error, but got \"%v\"", err)
+		}
+		return errors.New("intercepted: " + err.Error())
+	}
+	app.Commands = []Command{
+		{
+			Name: "bar",
+		},
+	}
+
+	err := app.Run([]string{"foo", "--flag=wrong", "bar"})
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	if !strings.HasPrefix(err.Error(), "intercepted: invalid value") {
+		t.Errorf("Expect an intercepted error, but got \"%v\"", err)
+	}
+}
+
+func TestHandleAction_WithNonFuncAction(t *testing.T) {
+	app := NewApp()
+	app.Action = 42
+	fs, err := flagSet(app.Name, app.Flags)
+	if err != nil {
+		t.Errorf("error creating FlagSet: %s", err)
+	}
+	err = HandleAction(app.Action, NewContext(app, fs, nil))
+
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	exitErr, ok := err.(*ExitError)
+
+	if !ok {
+		t.Fatalf("expected to receive a *ExitError")
+	}
+
+	if !strings.HasPrefix(exitErr.Error(), "ERROR invalid Action type.") {
+		t.Fatalf("expected an unknown Action error, but got: %v", exitErr.Error())
+	}
+
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("expected error exit code to be 2, but got: %v", exitErr.ExitCode())
+	}
+}
+
+func TestHandleAction_WithInvalidFuncSignature(t *testing.T) {
+	app := NewApp()
+	app.Action = func() string { return "" }
+	fs, err := flagSet(app.Name, app.Flags)
+	if err != nil {
+		t.Errorf("error creating FlagSet: %s", err)
+	}
+	err = HandleAction(app.Action, NewContext(app, fs, nil))
+
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	exitErr, ok := err.(*ExitError)
+
+	if !ok {
+		t.Fatalf("expected to receive a *ExitError")
+	}
+
+	if !strings.HasPrefix(exitErr.Error(), "ERROR invalid Action type") {
+		t.Fatalf("expected an unknown Action error, but got: %v", exitErr.Error())
+	}
+
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("expected error exit code to be 2, but got: %v", exitErr.ExitCode())
+	}
+}
+
+func TestHandleAction_WithInvalidFuncReturnSignature(t *testing.T) {
+	app := NewApp()
+	app.Action = func(_ *Context) (int, error) { return 0, nil }
+	fs, err := flagSet(app.Name, app.Flags)
+	if err != nil {
+		t.Errorf("error creating FlagSet: %s", err)
+	}
+	err = HandleAction(app.Action, NewContext(app, fs, nil))
+
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	exitErr, ok := err.(*ExitError)
+
+	if !ok {
+		t.Fatalf("expected to receive a *ExitError")
+	}
+
+	if !strings.HasPrefix(exitErr.Error(), "ERROR invalid Action type") {
+		t.Fatalf("expected an invalid Action signature error, but got: %v", exitErr.Error())
+	}
+
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("expected error exit code to be 2, but got: %v", exitErr.ExitCode())
+	}
+}
+
+func TestHandleAction_WithUnknownPanic(t *testing.T) {
+	defer func() { refute(t, recover(), nil) }()
+
+	var fn ActionFunc
+
+	app := NewApp()
+	app.Action = func(ctx *Context) error {
+		fn(ctx)
+		return nil
+	}
+	fs, err := flagSet(app.Name, app.Flags)
+	if err != nil {
+		t.Errorf("error creating FlagSet: %s", err)
+	}
+	HandleAction(app.Action, NewContext(app, fs, nil))
+}
+
+func TestShellCompletionForIncompleteFlags(t *testing.T) {
+	app := NewApp()
+	app.Flags = []Flag{
+		IntFlag{
+			Name: "test-completion",
+		},
+	}
+	app.EnableBashCompletion = true
+	app.BashComplete = func(ctx *Context) {
+		for _, command := range ctx.App.Commands {
+			if command.Hidden {
+				continue
+			}
+
+			for _, name := range command.Names() {
+				fmt.Fprintln(ctx.App.Writer, name)
+			}
+		}
+
+		for _, flag := range ctx.App.Flags {
+			for _, name := range strings.Split(flag.GetName(), ",") {
+				if name == BashCompletionFlag.Name {
+					continue
+				}
+
+				switch name = strings.TrimSpace(name); len(name) {
+				case 0:
+				case 1:
+					fmt.Fprintln(ctx.App.Writer, "-"+name)
+				default:
+					fmt.Fprintln(ctx.App.Writer, "--"+name)
+				}
+			}
+		}
+	}
+	app.Action = func(ctx *Context) error {
+		return fmt.Errorf("should not get here")
+	}
+	err := app.Run([]string{"", "--test-completion", "--" + BashCompletionFlag.Name})
+	if err != nil {
+		t.Errorf("app should not return an error: %s", err)
+	}
+}
+
+func TestHandleActionActuallyWorksWithActions(t *testing.T) {
+	var f ActionFunc
+	called := false
+	f = func(c *Context) error {
+		called = true
+		return nil
+	}
+
+	err := HandleAction(f, nil)
+
+	if err != nil {
+		t.Errorf("Should not have errored: %v", err)
+	}
+
+	if !called {
+		t.Errorf("Function was not called")
+	}
+}

--- a/vendor/github.com/urfave/cli/appveyor.yml
+++ b/vendor/github.com/urfave/cli/appveyor.yml
@@ -1,0 +1,24 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\gopath\src\github.com\urfave\cli
+
+environment:
+  GOPATH: C:\gopath
+  GOVERSION: 1.6
+  PYTHON: C:\Python27-x64
+  PYTHON_VERSION: 2.7.x
+  PYTHON_ARCH: 64
+
+install:
+- set PATH=%GOPATH%\bin;C:\go\bin;%PATH%
+- go version
+- go env
+- go get github.com/urfave/gfmrun/...
+- go get -v -t ./...
+
+build_script:
+- python runtests vet
+- python runtests test
+- python runtests gfmrun

--- a/vendor/github.com/urfave/cli/autocomplete/bash_autocomplete
+++ b/vendor/github.com/urfave/cli/autocomplete/bash_autocomplete
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+_cli_bash_autocomplete() {
+     local cur opts base
+     COMPREPLY=()
+     cur="${COMP_WORDS[COMP_CWORD]}"
+     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+     return 0
+ }
+  
+ complete -F _cli_bash_autocomplete $PROG

--- a/vendor/github.com/urfave/cli/autocomplete/zsh_autocomplete
+++ b/vendor/github.com/urfave/cli/autocomplete/zsh_autocomplete
@@ -1,0 +1,5 @@
+autoload -U compinit && compinit
+autoload -U bashcompinit && bashcompinit
+
+script_dir=$(dirname $0)
+source ${script_dir}/bash_autocomplete

--- a/vendor/github.com/urfave/cli/category.go
+++ b/vendor/github.com/urfave/cli/category.go
@@ -1,0 +1,44 @@
+package cli
+
+// CommandCategories is a slice of *CommandCategory.
+type CommandCategories []*CommandCategory
+
+// CommandCategory is a category containing commands.
+type CommandCategory struct {
+	Name     string
+	Commands Commands
+}
+
+func (c CommandCategories) Less(i, j int) bool {
+	return c[i].Name < c[j].Name
+}
+
+func (c CommandCategories) Len() int {
+	return len(c)
+}
+
+func (c CommandCategories) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+// AddCommand adds a command to a category.
+func (c CommandCategories) AddCommand(category string, command Command) CommandCategories {
+	for _, commandCategory := range c {
+		if commandCategory.Name == category {
+			commandCategory.Commands = append(commandCategory.Commands, command)
+			return c
+		}
+	}
+	return append(c, &CommandCategory{Name: category, Commands: []Command{command}})
+}
+
+// VisibleCommands returns a slice of the Commands with Hidden=false
+func (c *CommandCategory) VisibleCommands() []Command {
+	ret := []Command{}
+	for _, command := range c.Commands {
+		if !command.Hidden {
+			ret = append(ret, command)
+		}
+	}
+	return ret
+}

--- a/vendor/github.com/urfave/cli/cli.go
+++ b/vendor/github.com/urfave/cli/cli.go
@@ -1,0 +1,21 @@
+// Package cli provides a minimal framework for creating and organizing command line
+// Go applications. cli is designed to be easy to understand and write, the most simple
+// cli application can be written as follows:
+//   func main() {
+//     cli.NewApp().Run(os.Args)
+//   }
+//
+// Of course this application does not do much, so let's make this an actual application:
+//   func main() {
+//     app := cli.NewApp()
+//     app.Name = "greet"
+//     app.Usage = "say a greeting"
+//     app.Action = func(c *cli.Context) error {
+//       println("Greetings")
+//     }
+//
+//     app.Run(os.Args)
+//   }
+package cli
+
+//go:generate python ./generate-flag-types cli -i flag-types.json -o flag_generated.go

--- a/vendor/github.com/urfave/cli/command.go
+++ b/vendor/github.com/urfave/cli/command.go
@@ -1,0 +1,286 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"strings"
+)
+
+// Command is a subcommand for a cli.App.
+type Command struct {
+	// The name of the command
+	Name string
+	// short name of the command. Typically one character (deprecated, use `Aliases`)
+	ShortName string
+	// A list of aliases for the command
+	Aliases []string
+	// A short description of the usage of this command
+	Usage string
+	// Custom text to show on USAGE section of help
+	UsageText string
+	// A longer explanation of how the command works
+	Description string
+	// A short description of the arguments of this command
+	ArgsUsage string
+	// The category the command is part of
+	Category string
+	// The function to call when checking for bash command completions
+	BashComplete BashCompleteFunc
+	// An action to execute before any sub-subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no sub-subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+	// The function to call when this command is invoked
+	Action interface{}
+	// TODO: replace `Action: interface{}` with `Action: ActionFunc` once some kind
+	// of deprecation period has passed, maybe?
+
+	// Execute this function if a usage error occurs.
+	OnUsageError OnUsageErrorFunc
+	// List of child commands
+	Subcommands Commands
+	// List of flags to parse
+	Flags []Flag
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
+	// Skip argument reordering which attempts to move flags before arguments,
+	// but only works if all flags appear after all arguments. This behavior was
+	// removed n version 2 since it only works under specific conditions so we
+	// backport here by exposing it as an option for compatibility.
+	SkipArgReorder bool
+	// Boolean to hide built-in help command
+	HideHelp bool
+	// Boolean to hide this command from help or completion
+	Hidden bool
+
+	// Full name of command for help, defaults to full command name, including parent commands.
+	HelpName        string
+	commandNamePath []string
+}
+
+// FullName returns the full name of the command.
+// For subcommands this ensures that parent commands are part of the command path
+func (c Command) FullName() string {
+	if c.commandNamePath == nil {
+		return c.Name
+	}
+	return strings.Join(c.commandNamePath, " ")
+}
+
+// Commands is a slice of Command
+type Commands []Command
+
+// Run invokes the command given the context, parses ctx.Args() to generate command-specific flags
+func (c Command) Run(ctx *Context) (err error) {
+	if len(c.Subcommands) > 0 {
+		return c.startApp(ctx)
+	}
+
+	if !c.HideHelp && (HelpFlag != BoolFlag{}) {
+		// append help to flags
+		c.Flags = append(
+			c.Flags,
+			HelpFlag,
+		)
+	}
+
+	set, err := flagSet(c.Name, c.Flags)
+	if err != nil {
+		return err
+	}
+	set.SetOutput(ioutil.Discard)
+
+	if c.SkipFlagParsing {
+		err = set.Parse(append([]string{"--"}, ctx.Args().Tail()...))
+	} else if !c.SkipArgReorder {
+		firstFlagIndex := -1
+		terminatorIndex := -1
+		for index, arg := range ctx.Args() {
+			if arg == "--" {
+				terminatorIndex = index
+				break
+			} else if arg == "-" {
+				// Do nothing. A dash alone is not really a flag.
+				continue
+			} else if strings.HasPrefix(arg, "-") && firstFlagIndex == -1 {
+				firstFlagIndex = index
+			}
+		}
+
+		if firstFlagIndex > -1 {
+			args := ctx.Args()
+			regularArgs := make([]string, len(args[1:firstFlagIndex]))
+			copy(regularArgs, args[1:firstFlagIndex])
+
+			var flagArgs []string
+			if terminatorIndex > -1 {
+				flagArgs = args[firstFlagIndex:terminatorIndex]
+				regularArgs = append(regularArgs, args[terminatorIndex:]...)
+			} else {
+				flagArgs = args[firstFlagIndex:]
+			}
+
+			err = set.Parse(append(flagArgs, regularArgs...))
+		} else {
+			err = set.Parse(ctx.Args().Tail())
+		}
+	} else {
+		err = set.Parse(ctx.Args().Tail())
+	}
+
+	nerr := normalizeFlags(c.Flags, set)
+	if nerr != nil {
+		fmt.Fprintln(ctx.App.Writer, nerr)
+		fmt.Fprintln(ctx.App.Writer)
+		ShowCommandHelp(ctx, c.Name)
+		return nerr
+	}
+
+	context := NewContext(ctx.App, set, ctx)
+	if checkCommandCompletions(context, c.Name) {
+		return nil
+	}
+
+	if err != nil {
+		if c.OnUsageError != nil {
+			err := c.OnUsageError(ctx, err, false)
+			HandleExitCoder(err)
+			return err
+		}
+		fmt.Fprintln(ctx.App.Writer, "Incorrect Usage:", err.Error())
+		fmt.Fprintln(ctx.App.Writer)
+		ShowCommandHelp(ctx, c.Name)
+		return err
+	}
+
+	if checkCommandHelp(context, c.Name) {
+		return nil
+	}
+
+	if c.After != nil {
+		defer func() {
+			afterErr := c.After(context)
+			if afterErr != nil {
+				HandleExitCoder(err)
+				if err != nil {
+					err = NewMultiError(err, afterErr)
+				} else {
+					err = afterErr
+				}
+			}
+		}()
+	}
+
+	if c.Before != nil {
+		err = c.Before(context)
+		if err != nil {
+			fmt.Fprintln(ctx.App.Writer, err)
+			fmt.Fprintln(ctx.App.Writer)
+			ShowCommandHelp(ctx, c.Name)
+			HandleExitCoder(err)
+			return err
+		}
+	}
+
+	if c.Action == nil {
+		c.Action = helpSubcommand.Action
+	}
+
+	context.Command = c
+	err = HandleAction(c.Action, context)
+
+	if err != nil {
+		HandleExitCoder(err)
+	}
+	return err
+}
+
+// Names returns the names including short names and aliases.
+func (c Command) Names() []string {
+	names := []string{c.Name}
+
+	if c.ShortName != "" {
+		names = append(names, c.ShortName)
+	}
+
+	return append(names, c.Aliases...)
+}
+
+// HasName returns true if Command.Name or Command.ShortName matches given name
+func (c Command) HasName(name string) bool {
+	for _, n := range c.Names() {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Command) startApp(ctx *Context) error {
+	app := NewApp()
+	app.Metadata = ctx.App.Metadata
+	// set the name and usage
+	app.Name = fmt.Sprintf("%s %s", ctx.App.Name, c.Name)
+	if c.HelpName == "" {
+		app.HelpName = c.HelpName
+	} else {
+		app.HelpName = app.Name
+	}
+
+	if c.Description != "" {
+		app.Usage = c.Description
+	} else {
+		app.Usage = c.Usage
+	}
+
+	// set CommandNotFound
+	app.CommandNotFound = ctx.App.CommandNotFound
+
+	// set the flags and commands
+	app.Commands = c.Subcommands
+	app.Flags = c.Flags
+	app.HideHelp = c.HideHelp
+
+	app.Version = ctx.App.Version
+	app.HideVersion = ctx.App.HideVersion
+	app.Compiled = ctx.App.Compiled
+	app.Author = ctx.App.Author
+	app.Email = ctx.App.Email
+	app.Writer = ctx.App.Writer
+
+	app.categories = CommandCategories{}
+	for _, command := range c.Subcommands {
+		app.categories = app.categories.AddCommand(command.Category, command)
+	}
+
+	sort.Sort(app.categories)
+
+	// bash completion
+	app.EnableBashCompletion = ctx.App.EnableBashCompletion
+	if c.BashComplete != nil {
+		app.BashComplete = c.BashComplete
+	}
+
+	// set the actions
+	app.Before = c.Before
+	app.After = c.After
+	if c.Action != nil {
+		app.Action = c.Action
+	} else {
+		app.Action = helpSubcommand.Action
+	}
+
+	for index, cc := range app.Commands {
+		app.Commands[index].commandNamePath = []string{c.Name, cc.Name}
+	}
+
+	return app.RunAsSubcommand(ctx)
+}
+
+// VisibleFlags returns a slice of the Flags with Hidden=false
+func (c Command) VisibleFlags() []Flag {
+	return visibleFlags(c.Flags)
+}

--- a/vendor/github.com/urfave/cli/command_test.go
+++ b/vendor/github.com/urfave/cli/command_test.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestCommandFlagParsing(t *testing.T) {
+	cases := []struct {
+		testArgs        []string
+		skipFlagParsing bool
+		skipArgReorder  bool
+		expectedErr     error
+	}{
+		// Test normal "not ignoring flags" flow
+		{[]string{"test-cmd", "blah", "blah", "-break"}, false, false, errors.New("flag provided but not defined: -break")},
+
+		// Test no arg reorder
+		{[]string{"test-cmd", "blah", "blah", "-break"}, false, true, nil},
+
+		{[]string{"test-cmd", "blah", "blah"}, true, false, nil},   // Test SkipFlagParsing without any args that look like flags
+		{[]string{"test-cmd", "blah", "-break"}, true, false, nil}, // Test SkipFlagParsing with random flag arg
+		{[]string{"test-cmd", "blah", "-help"}, true, false, nil},  // Test SkipFlagParsing with "special" help flag arg
+	}
+
+	for _, c := range cases {
+		app := NewApp()
+		app.Writer = ioutil.Discard
+		set := flag.NewFlagSet("test", 0)
+		set.Parse(c.testArgs)
+
+		context := NewContext(app, set, nil)
+
+		command := Command{
+			Name:            "test-cmd",
+			Aliases:         []string{"tc"},
+			Usage:           "this is for testing",
+			Description:     "testing",
+			Action:          func(_ *Context) error { return nil },
+			SkipFlagParsing: c.skipFlagParsing,
+			SkipArgReorder:  c.skipArgReorder,
+		}
+
+		err := command.Run(context)
+
+		expect(t, err, c.expectedErr)
+		expect(t, []string(context.Args()), c.testArgs)
+	}
+}
+
+func TestCommand_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
+	app := NewApp()
+	app.Commands = []Command{
+		{
+			Name: "bar",
+			Before: func(c *Context) error {
+				return fmt.Errorf("before error")
+			},
+			After: func(c *Context) error {
+				return fmt.Errorf("after error")
+			},
+		},
+	}
+
+	err := app.Run([]string{"foo", "bar"})
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	if !strings.Contains(err.Error(), "before error") {
+		t.Errorf("expected text of error from Before method, but got none in \"%v\"", err)
+	}
+	if !strings.Contains(err.Error(), "after error") {
+		t.Errorf("expected text of error from After method, but got none in \"%v\"", err)
+	}
+}
+
+func TestCommand_Run_BeforeSavesMetadata(t *testing.T) {
+	var receivedMsgFromAction string
+	var receivedMsgFromAfter string
+
+	app := NewApp()
+	app.Commands = []Command{
+		{
+			Name: "bar",
+			Before: func(c *Context) error {
+				c.App.Metadata["msg"] = "hello world"
+				return nil
+			},
+			Action: func(c *Context) error {
+				msg, ok := c.App.Metadata["msg"]
+				if !ok {
+					return errors.New("msg not found")
+				}
+				receivedMsgFromAction = msg.(string)
+				return nil
+			},
+			After: func(c *Context) error {
+				msg, ok := c.App.Metadata["msg"]
+				if !ok {
+					return errors.New("msg not found")
+				}
+				receivedMsgFromAfter = msg.(string)
+				return nil
+			},
+		},
+	}
+
+	err := app.Run([]string{"foo", "bar"})
+	if err != nil {
+		t.Fatalf("expected no error from Run, got %s", err)
+	}
+
+	expectedMsg := "hello world"
+
+	if receivedMsgFromAction != expectedMsg {
+		t.Fatalf("expected msg from Action to match. Given: %q\nExpected: %q",
+			receivedMsgFromAction, expectedMsg)
+	}
+	if receivedMsgFromAfter != expectedMsg {
+		t.Fatalf("expected msg from After to match. Given: %q\nExpected: %q",
+			receivedMsgFromAction, expectedMsg)
+	}
+}
+
+func TestCommand_OnUsageError_WithWrongFlagValue(t *testing.T) {
+	app := NewApp()
+	app.Commands = []Command{
+		{
+			Name: "bar",
+			Flags: []Flag{
+				IntFlag{Name: "flag"},
+			},
+			OnUsageError: func(c *Context, err error, _ bool) error {
+				if !strings.HasPrefix(err.Error(), "invalid value \"wrong\"") {
+					t.Errorf("Expect an invalid value error, but got \"%v\"", err)
+				}
+				return errors.New("intercepted: " + err.Error())
+			},
+		},
+	}
+
+	err := app.Run([]string{"foo", "bar", "--flag=wrong"})
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	if !strings.HasPrefix(err.Error(), "intercepted: invalid value") {
+		t.Errorf("Expect an intercepted error, but got \"%v\"", err)
+	}
+}

--- a/vendor/github.com/urfave/cli/context.go
+++ b/vendor/github.com/urfave/cli/context.go
@@ -1,0 +1,276 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"reflect"
+	"strings"
+	"syscall"
+)
+
+// Context is a type that is passed through to
+// each Handler action in a cli application. Context
+// can be used to retrieve context-specific Args and
+// parsed command-line options.
+type Context struct {
+	App           *App
+	Command       Command
+	shellComplete bool
+	flagSet       *flag.FlagSet
+	setFlags      map[string]bool
+	parentContext *Context
+}
+
+// NewContext creates a new context. For use in when invoking an App or Command action.
+func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
+	c := &Context{App: app, flagSet: set, parentContext: parentCtx}
+
+	if parentCtx != nil {
+		c.shellComplete = parentCtx.shellComplete
+	}
+
+	return c
+}
+
+// NumFlags returns the number of flags set
+func (c *Context) NumFlags() int {
+	return c.flagSet.NFlag()
+}
+
+// Set sets a context flag to a value.
+func (c *Context) Set(name, value string) error {
+	return c.flagSet.Set(name, value)
+}
+
+// GlobalSet sets a context flag to a value on the global flagset
+func (c *Context) GlobalSet(name, value string) error {
+	return globalContext(c).flagSet.Set(name, value)
+}
+
+// IsSet determines if the flag was actually set
+func (c *Context) IsSet(name string) bool {
+	if c.setFlags == nil {
+		c.setFlags = make(map[string]bool)
+
+		c.flagSet.Visit(func(f *flag.Flag) {
+			c.setFlags[f.Name] = true
+		})
+
+		c.flagSet.VisitAll(func(f *flag.Flag) {
+			if _, ok := c.setFlags[f.Name]; ok {
+				return
+			}
+			c.setFlags[f.Name] = false
+		})
+
+		// XXX hack to support IsSet for flags with EnvVar
+		//
+		// There isn't an easy way to do this with the current implementation since
+		// whether a flag was set via an environment variable is very difficult to
+		// determine here. Instead, we intend to introduce a backwards incompatible
+		// change in version 2 to add `IsSet` to the Flag interface to push the
+		// responsibility closer to where the information required to determine
+		// whether a flag is set by non-standard means such as environment
+		// variables is avaliable.
+		//
+		// See https://github.com/urfave/cli/issues/294 for additional discussion
+		flags := c.Command.Flags
+		if c.Command.Name == "" { // cannot == Command{} since it contains slice types
+			if c.App != nil {
+				flags = c.App.Flags
+			}
+		}
+		for _, f := range flags {
+			eachName(f.GetName(), func(name string) {
+				if isSet, ok := c.setFlags[name]; isSet || !ok {
+					return
+				}
+
+				val := reflect.ValueOf(f)
+				if val.Kind() == reflect.Ptr {
+					val = val.Elem()
+				}
+
+				envVarValue := val.FieldByName("EnvVar")
+				if !envVarValue.IsValid() {
+					return
+				}
+
+				eachName(envVarValue.String(), func(envVar string) {
+					envVar = strings.TrimSpace(envVar)
+					if _, ok := syscall.Getenv(envVar); ok {
+						c.setFlags[name] = true
+						return
+					}
+				})
+			})
+		}
+	}
+
+	return c.setFlags[name]
+}
+
+// GlobalIsSet determines if the global flag was actually set
+func (c *Context) GlobalIsSet(name string) bool {
+	ctx := c
+	if ctx.parentContext != nil {
+		ctx = ctx.parentContext
+	}
+
+	for ; ctx != nil; ctx = ctx.parentContext {
+		if ctx.IsSet(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// FlagNames returns a slice of flag names used in this context.
+func (c *Context) FlagNames() (names []string) {
+	for _, flag := range c.Command.Flags {
+		name := strings.Split(flag.GetName(), ",")[0]
+		if name == "help" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return
+}
+
+// GlobalFlagNames returns a slice of global flag names used by the app.
+func (c *Context) GlobalFlagNames() (names []string) {
+	for _, flag := range c.App.Flags {
+		name := strings.Split(flag.GetName(), ",")[0]
+		if name == "help" || name == "version" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return
+}
+
+// Parent returns the parent context, if any
+func (c *Context) Parent() *Context {
+	return c.parentContext
+}
+
+// value returns the value of the flag coressponding to `name`
+func (c *Context) value(name string) interface{} {
+	return c.flagSet.Lookup(name).Value.(flag.Getter).Get()
+}
+
+// Args contains apps console arguments
+type Args []string
+
+// Args returns the command line arguments associated with the context.
+func (c *Context) Args() Args {
+	args := Args(c.flagSet.Args())
+	return args
+}
+
+// NArg returns the number of the command line arguments.
+func (c *Context) NArg() int {
+	return len(c.Args())
+}
+
+// Get returns the nth argument, or else a blank string
+func (a Args) Get(n int) string {
+	if len(a) > n {
+		return a[n]
+	}
+	return ""
+}
+
+// First returns the first argument, or else a blank string
+func (a Args) First() string {
+	return a.Get(0)
+}
+
+// Tail returns the rest of the arguments (not the first one)
+// or else an empty string slice
+func (a Args) Tail() []string {
+	if len(a) >= 2 {
+		return []string(a)[1:]
+	}
+	return []string{}
+}
+
+// Present checks if there are any arguments present
+func (a Args) Present() bool {
+	return len(a) != 0
+}
+
+// Swap swaps arguments at the given indexes
+func (a Args) Swap(from, to int) error {
+	if from >= len(a) || to >= len(a) {
+		return errors.New("index out of range")
+	}
+	a[from], a[to] = a[to], a[from]
+	return nil
+}
+
+func globalContext(ctx *Context) *Context {
+	if ctx == nil {
+		return nil
+	}
+
+	for {
+		if ctx.parentContext == nil {
+			return ctx
+		}
+		ctx = ctx.parentContext
+	}
+}
+
+func lookupGlobalFlagSet(name string, ctx *Context) *flag.FlagSet {
+	if ctx.parentContext != nil {
+		ctx = ctx.parentContext
+	}
+	for ; ctx != nil; ctx = ctx.parentContext {
+		if f := ctx.flagSet.Lookup(name); f != nil {
+			return ctx.flagSet
+		}
+	}
+	return nil
+}
+
+func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {
+	switch ff.Value.(type) {
+	case *StringSlice:
+	default:
+		set.Set(name, ff.Value.String())
+	}
+}
+
+func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
+	visited := make(map[string]bool)
+	set.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+	for _, f := range flags {
+		parts := strings.Split(f.GetName(), ",")
+		if len(parts) == 1 {
+			continue
+		}
+		var ff *flag.Flag
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if visited[name] {
+				if ff != nil {
+					return errors.New("Cannot use two forms of the same flag: " + name + " " + ff.Name)
+				}
+				ff = set.Lookup(name)
+			}
+		}
+		if ff == nil {
+			continue
+		}
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if !visited[name] {
+				copyFlag(name, ff, set)
+			}
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/context_test.go
+++ b/vendor/github.com/urfave/cli/context_test.go
@@ -1,0 +1,399 @@
+package cli
+
+import (
+	"flag"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestNewContext(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int("myflag", 12, "doc")
+	set.Int64("myflagInt64", int64(12), "doc")
+	set.Uint("myflagUint", uint(93), "doc")
+	set.Uint64("myflagUint64", uint64(93), "doc")
+	set.Float64("myflag64", float64(17), "doc")
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.Int("myflag", 42, "doc")
+	globalSet.Int64("myflagInt64", int64(42), "doc")
+	globalSet.Uint("myflagUint", uint(33), "doc")
+	globalSet.Uint64("myflagUint64", uint64(33), "doc")
+	globalSet.Float64("myflag64", float64(47), "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+	command := Command{Name: "mycommand"}
+	c := NewContext(nil, set, globalCtx)
+	c.Command = command
+	expect(t, c.Int("myflag"), 12)
+	expect(t, c.Int64("myflagInt64"), int64(12))
+	expect(t, c.Uint("myflagUint"), uint(93))
+	expect(t, c.Uint64("myflagUint64"), uint64(93))
+	expect(t, c.Float64("myflag64"), float64(17))
+	expect(t, c.GlobalInt("myflag"), 42)
+	expect(t, c.GlobalInt64("myflagInt64"), int64(42))
+	expect(t, c.GlobalUint("myflagUint"), uint(33))
+	expect(t, c.GlobalUint64("myflagUint64"), uint64(33))
+	expect(t, c.GlobalFloat64("myflag64"), float64(47))
+	expect(t, c.Command.Name, "mycommand")
+}
+
+func TestContext_Int(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int("myflag", 12, "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Int("myflag"), 12)
+}
+
+func TestContext_Int64(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int64("myflagInt64", 12, "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Int64("myflagInt64"), int64(12))
+}
+
+func TestContext_Uint(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Uint("myflagUint", uint(13), "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Uint("myflagUint"), uint(13))
+}
+
+func TestContext_Uint64(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Uint64("myflagUint64", uint64(9), "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Uint64("myflagUint64"), uint64(9))
+}
+
+func TestContext_GlobalInt(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int("myflag", 12, "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.GlobalInt("myflag"), 12)
+	expect(t, c.GlobalInt("nope"), 0)
+}
+
+func TestContext_GlobalInt64(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int64("myflagInt64", 12, "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.GlobalInt64("myflagInt64"), int64(12))
+	expect(t, c.GlobalInt64("nope"), int64(0))
+}
+
+func TestContext_Float64(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Float64("myflag", float64(17), "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Float64("myflag"), float64(17))
+}
+
+func TestContext_GlobalFloat64(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Float64("myflag", float64(17), "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.GlobalFloat64("myflag"), float64(17))
+	expect(t, c.GlobalFloat64("nope"), float64(0))
+}
+
+func TestContext_Duration(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Duration("myflag", time.Duration(12*time.Second), "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Duration("myflag"), time.Duration(12*time.Second))
+}
+
+func TestContext_String(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.String("myflag", "hello world", "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.String("myflag"), "hello world")
+}
+
+func TestContext_Bool(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Bool("myflag"), false)
+}
+
+func TestContext_BoolT(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", true, "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.BoolT("myflag"), true)
+}
+
+func TestContext_GlobalBool(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+
+	globalSet := flag.NewFlagSet("test-global", 0)
+	globalSet.Bool("myflag", false, "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+
+	c := NewContext(nil, set, globalCtx)
+	expect(t, c.GlobalBool("myflag"), false)
+	expect(t, c.GlobalBool("nope"), false)
+}
+
+func TestContext_GlobalBoolT(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+
+	globalSet := flag.NewFlagSet("test-global", 0)
+	globalSet.Bool("myflag", true, "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+
+	c := NewContext(nil, set, globalCtx)
+	expect(t, c.GlobalBoolT("myflag"), true)
+	expect(t, c.GlobalBoolT("nope"), false)
+}
+
+func TestContext_Args(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	c := NewContext(nil, set, nil)
+	set.Parse([]string{"--myflag", "bat", "baz"})
+	expect(t, len(c.Args()), 2)
+	expect(t, c.Bool("myflag"), true)
+}
+
+func TestContext_NArg(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	c := NewContext(nil, set, nil)
+	set.Parse([]string{"--myflag", "bat", "baz"})
+	expect(t, c.NArg(), 2)
+}
+
+func TestContext_IsSet(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	set.String("otherflag", "hello world", "doc")
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.Bool("myflagGlobal", true, "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+	c := NewContext(nil, set, globalCtx)
+	set.Parse([]string{"--myflag", "bat", "baz"})
+	globalSet.Parse([]string{"--myflagGlobal", "bat", "baz"})
+	expect(t, c.IsSet("myflag"), true)
+	expect(t, c.IsSet("otherflag"), false)
+	expect(t, c.IsSet("bogusflag"), false)
+	expect(t, c.IsSet("myflagGlobal"), false)
+}
+
+// XXX Corresponds to hack in context.IsSet for flags with EnvVar field
+// Should be moved to `flag_test` in v2
+func TestContext_IsSet_fromEnv(t *testing.T) {
+	var (
+		timeoutIsSet, tIsSet    bool
+		noEnvVarIsSet, nIsSet   bool
+		passwordIsSet, pIsSet   bool
+		unparsableIsSet, uIsSet bool
+	)
+
+	clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "15.5")
+	os.Setenv("APP_PASSWORD", "")
+	a := App{
+		Flags: []Flag{
+			Float64Flag{Name: "timeout, t", EnvVar: "APP_TIMEOUT_SECONDS"},
+			StringFlag{Name: "password, p", EnvVar: "APP_PASSWORD"},
+			Float64Flag{Name: "unparsable, u", EnvVar: "APP_UNPARSABLE"},
+			Float64Flag{Name: "no-env-var, n"},
+		},
+		Action: func(ctx *Context) error {
+			timeoutIsSet = ctx.IsSet("timeout")
+			tIsSet = ctx.IsSet("t")
+			passwordIsSet = ctx.IsSet("password")
+			pIsSet = ctx.IsSet("p")
+			unparsableIsSet = ctx.IsSet("unparsable")
+			uIsSet = ctx.IsSet("u")
+			noEnvVarIsSet = ctx.IsSet("no-env-var")
+			nIsSet = ctx.IsSet("n")
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+	expect(t, timeoutIsSet, true)
+	expect(t, tIsSet, true)
+	expect(t, passwordIsSet, true)
+	expect(t, pIsSet, true)
+	expect(t, noEnvVarIsSet, false)
+	expect(t, nIsSet, false)
+
+	os.Setenv("APP_UNPARSABLE", "foobar")
+	a.Run([]string{"run"})
+	expect(t, unparsableIsSet, false)
+	expect(t, uIsSet, false)
+}
+
+func TestContext_GlobalIsSet(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	set.String("otherflag", "hello world", "doc")
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.Bool("myflagGlobal", true, "doc")
+	globalSet.Bool("myflagGlobalUnset", true, "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+	c := NewContext(nil, set, globalCtx)
+	set.Parse([]string{"--myflag", "bat", "baz"})
+	globalSet.Parse([]string{"--myflagGlobal", "bat", "baz"})
+	expect(t, c.GlobalIsSet("myflag"), false)
+	expect(t, c.GlobalIsSet("otherflag"), false)
+	expect(t, c.GlobalIsSet("bogusflag"), false)
+	expect(t, c.GlobalIsSet("myflagGlobal"), true)
+	expect(t, c.GlobalIsSet("myflagGlobalUnset"), false)
+	expect(t, c.GlobalIsSet("bogusGlobal"), false)
+}
+
+// XXX Corresponds to hack in context.IsSet for flags with EnvVar field
+// Should be moved to `flag_test` in v2
+func TestContext_GlobalIsSet_fromEnv(t *testing.T) {
+	var (
+		timeoutIsSet, tIsSet    bool
+		noEnvVarIsSet, nIsSet   bool
+		passwordIsSet, pIsSet   bool
+		unparsableIsSet, uIsSet bool
+	)
+
+	clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "15.5")
+	os.Setenv("APP_PASSWORD", "")
+	a := App{
+		Flags: []Flag{
+			Float64Flag{Name: "timeout, t", EnvVar: "APP_TIMEOUT_SECONDS"},
+			StringFlag{Name: "password, p", EnvVar: "APP_PASSWORD"},
+			Float64Flag{Name: "no-env-var, n"},
+			Float64Flag{Name: "unparsable, u", EnvVar: "APP_UNPARSABLE"},
+		},
+		Commands: []Command{
+			{
+				Name: "hello",
+				Action: func(ctx *Context) error {
+					timeoutIsSet = ctx.GlobalIsSet("timeout")
+					tIsSet = ctx.GlobalIsSet("t")
+					passwordIsSet = ctx.GlobalIsSet("password")
+					pIsSet = ctx.GlobalIsSet("p")
+					unparsableIsSet = ctx.GlobalIsSet("unparsable")
+					uIsSet = ctx.GlobalIsSet("u")
+					noEnvVarIsSet = ctx.GlobalIsSet("no-env-var")
+					nIsSet = ctx.GlobalIsSet("n")
+					return nil
+				},
+			},
+		},
+	}
+	if err := a.Run([]string{"run", "hello"}); err != nil {
+		t.Logf("error running Run(): %+v", err)
+	}
+	expect(t, timeoutIsSet, true)
+	expect(t, tIsSet, true)
+	expect(t, passwordIsSet, true)
+	expect(t, pIsSet, true)
+	expect(t, noEnvVarIsSet, false)
+	expect(t, nIsSet, false)
+
+	os.Setenv("APP_UNPARSABLE", "foobar")
+	if err := a.Run([]string{"run"}); err != nil {
+		t.Logf("error running Run(): %+v", err)
+	}
+	expect(t, unparsableIsSet, false)
+	expect(t, uIsSet, false)
+}
+
+func TestContext_NumFlags(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	set.String("otherflag", "hello world", "doc")
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.Bool("myflagGlobal", true, "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+	c := NewContext(nil, set, globalCtx)
+	set.Parse([]string{"--myflag", "--otherflag=foo"})
+	globalSet.Parse([]string{"--myflagGlobal"})
+	expect(t, c.NumFlags(), 2)
+}
+
+func TestContext_GlobalFlag(t *testing.T) {
+	var globalFlag string
+	var globalFlagSet bool
+	app := NewApp()
+	app.Flags = []Flag{
+		StringFlag{Name: "global, g", Usage: "global"},
+	}
+	app.Action = func(c *Context) error {
+		globalFlag = c.GlobalString("global")
+		globalFlagSet = c.GlobalIsSet("global")
+		return nil
+	}
+	app.Run([]string{"command", "-g", "foo"})
+	expect(t, globalFlag, "foo")
+	expect(t, globalFlagSet, true)
+
+}
+
+func TestContext_GlobalFlagsInSubcommands(t *testing.T) {
+	subcommandRun := false
+	parentFlag := false
+	app := NewApp()
+
+	app.Flags = []Flag{
+		BoolFlag{Name: "debug, d", Usage: "Enable debugging"},
+	}
+
+	app.Commands = []Command{
+		{
+			Name: "foo",
+			Flags: []Flag{
+				BoolFlag{Name: "parent, p", Usage: "Parent flag"},
+			},
+			Subcommands: []Command{
+				{
+					Name: "bar",
+					Action: func(c *Context) error {
+						if c.GlobalBool("debug") {
+							subcommandRun = true
+						}
+						if c.GlobalBool("parent") {
+							parentFlag = true
+						}
+						return nil
+					},
+				},
+			},
+		},
+	}
+
+	app.Run([]string{"command", "-d", "foo", "-p", "bar"})
+
+	expect(t, subcommandRun, true)
+	expect(t, parentFlag, true)
+}
+
+func TestContext_Set(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int("int", 5, "an int")
+	c := NewContext(nil, set, nil)
+
+	c.Set("int", "1")
+	expect(t, c.Int("int"), 1)
+}
+
+func TestContext_GlobalSet(t *testing.T) {
+	gSet := flag.NewFlagSet("test", 0)
+	gSet.Int("int", 5, "an int")
+
+	set := flag.NewFlagSet("sub", 0)
+	set.Int("int", 3, "an int")
+
+	pc := NewContext(nil, gSet, nil)
+	c := NewContext(nil, set, pc)
+
+	c.Set("int", "1")
+	expect(t, c.Int("int"), 1)
+	expect(t, c.GlobalInt("int"), 5)
+
+	c.GlobalSet("int", "1")
+	expect(t, c.Int("int"), 1)
+	expect(t, c.GlobalInt("int"), 1)
+}

--- a/vendor/github.com/urfave/cli/errors.go
+++ b/vendor/github.com/urfave/cli/errors.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// OsExiter is the function used when the app exits. If not set defaults to os.Exit.
+var OsExiter = os.Exit
+
+// ErrWriter is used to write errors to the user. This can be anything
+// implementing the io.Writer interface and defaults to os.Stderr.
+var ErrWriter io.Writer = os.Stderr
+
+// MultiError is an error that wraps multiple errors.
+type MultiError struct {
+	Errors []error
+}
+
+// NewMultiError creates a new MultiError. Pass in one or more errors.
+func NewMultiError(err ...error) MultiError {
+	return MultiError{Errors: err}
+}
+
+// Error implements the error interface.
+func (m MultiError) Error() string {
+	errs := make([]string, len(m.Errors))
+	for i, err := range m.Errors {
+		errs[i] = err.Error()
+	}
+
+	return strings.Join(errs, "\n")
+}
+
+type ErrorFormatter interface {
+	Format(s fmt.State, verb rune)
+}
+
+// ExitCoder is the interface checked by `App` and `Command` for a custom exit
+// code
+type ExitCoder interface {
+	error
+	ExitCode() int
+}
+
+// ExitError fulfills both the builtin `error` interface and `ExitCoder`
+type ExitError struct {
+	exitCode int
+	message  interface{}
+}
+
+// NewExitError makes a new *ExitError
+func NewExitError(message interface{}, exitCode int) *ExitError {
+	return &ExitError{
+		exitCode: exitCode,
+		message:  message,
+	}
+}
+
+// Error returns the string message, fulfilling the interface required by
+// `error`
+func (ee *ExitError) Error() string {
+	return fmt.Sprintf("%v", ee.message)
+}
+
+// ExitCode returns the exit code, fulfilling the interface required by
+// `ExitCoder`
+func (ee *ExitError) ExitCode() int {
+	return ee.exitCode
+}
+
+// HandleExitCoder checks if the error fulfills the ExitCoder interface, and if
+// so prints the error to stderr (if it is non-empty) and calls OsExiter with the
+// given exit code.  If the given error is a MultiError, then this func is
+// called on all members of the Errors slice.
+func HandleExitCoder(err error) {
+	if err == nil {
+		return
+	}
+
+	if exitErr, ok := err.(ExitCoder); ok {
+		if err.Error() != "" {
+			if _, ok := exitErr.(ErrorFormatter); ok {
+				fmt.Fprintf(ErrWriter, "%+v\n", err)
+			} else {
+				fmt.Fprintln(ErrWriter, err)
+			}
+		}
+		OsExiter(exitErr.ExitCode())
+		return
+	}
+
+	if multiErr, ok := err.(MultiError); ok {
+		for _, merr := range multiErr.Errors {
+			HandleExitCoder(merr)
+		}
+		return
+	}
+
+	if err.Error() != "" {
+		if _, ok := err.(ErrorFormatter); ok {
+			fmt.Fprintf(ErrWriter, "%+v\n", err)
+		} else {
+			fmt.Fprintln(ErrWriter, err)
+		}
+	}
+	OsExiter(1)
+}

--- a/vendor/github.com/urfave/cli/errors_test.go
+++ b/vendor/github.com/urfave/cli/errors_test.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestHandleExitCoder_nil(t *testing.T) {
+	exitCode := 0
+	called := false
+
+	OsExiter = func(rc int) {
+		exitCode = rc
+		called = true
+	}
+
+	defer func() { OsExiter = fakeOsExiter }()
+
+	HandleExitCoder(nil)
+
+	expect(t, exitCode, 0)
+	expect(t, called, false)
+}
+
+func TestHandleExitCoder_ExitCoder(t *testing.T) {
+	exitCode := 0
+	called := false
+
+	OsExiter = func(rc int) {
+		exitCode = rc
+		called = true
+	}
+
+	defer func() { OsExiter = fakeOsExiter }()
+
+	HandleExitCoder(NewExitError("galactic perimeter breach", 9))
+
+	expect(t, exitCode, 9)
+	expect(t, called, true)
+}
+
+func TestHandleExitCoder_MultiErrorWithExitCoder(t *testing.T) {
+	exitCode := 0
+	called := false
+
+	OsExiter = func(rc int) {
+		exitCode = rc
+		called = true
+	}
+
+	defer func() { OsExiter = fakeOsExiter }()
+
+	exitErr := NewExitError("galactic perimeter breach", 9)
+	err := NewMultiError(errors.New("wowsa"), errors.New("egad"), exitErr)
+	HandleExitCoder(err)
+
+	expect(t, exitCode, 9)
+	expect(t, called, true)
+}
+
+func TestHandleExitCoder_ErrorWithMessage(t *testing.T) {
+	exitCode := 0
+	called := false
+
+	OsExiter = func(rc int) {
+		exitCode = rc
+		called = true
+	}
+	ErrWriter = &bytes.Buffer{}
+
+	defer func() {
+		OsExiter = fakeOsExiter
+		ErrWriter = fakeErrWriter
+	}()
+
+	err := errors.New("gourd havens")
+	HandleExitCoder(err)
+
+	expect(t, exitCode, 1)
+	expect(t, called, true)
+	expect(t, ErrWriter.(*bytes.Buffer).String(), "gourd havens\n")
+}
+
+func TestHandleExitCoder_ErrorWithoutMessage(t *testing.T) {
+	exitCode := 0
+	called := false
+
+	OsExiter = func(rc int) {
+		exitCode = rc
+		called = true
+	}
+	ErrWriter = &bytes.Buffer{}
+
+	defer func() {
+		OsExiter = fakeOsExiter
+		ErrWriter = fakeErrWriter
+	}()
+
+	err := errors.New("")
+	HandleExitCoder(err)
+
+	expect(t, exitCode, 1)
+	expect(t, called, true)
+	expect(t, ErrWriter.(*bytes.Buffer).String(), "")
+}
+
+// make a stub to not import pkg/errors
+type ErrorWithFormat struct {
+	error
+}
+
+func NewErrorWithFormat(m string) *ErrorWithFormat {
+	return &ErrorWithFormat{error: errors.New(m)}
+}
+
+func (f *ErrorWithFormat) Format(s fmt.State, verb rune) {
+	fmt.Fprintf(s, "This the format: %v", f.error)
+}
+
+func TestHandleExitCoder_ErrorWithFormat(t *testing.T) {
+	called := false
+
+	OsExiter = func(rc int) {
+		called = true
+	}
+	ErrWriter = &bytes.Buffer{}
+
+	defer func() {
+		OsExiter = fakeOsExiter
+		ErrWriter = fakeErrWriter
+	}()
+
+	err := NewErrorWithFormat("I am formatted")
+	HandleExitCoder(err)
+
+	expect(t, called, true)
+	expect(t, ErrWriter.(*bytes.Buffer).String(), "This the format: I am formatted\n")
+}
+
+func TestHandleExitCoder_MultiErrorWithFormat(t *testing.T) {
+	called := false
+
+	OsExiter = func(rc int) {
+		called = true
+	}
+	ErrWriter = &bytes.Buffer{}
+
+	defer func() { OsExiter = fakeOsExiter }()
+
+	err := NewMultiError(NewErrorWithFormat("err1"), NewErrorWithFormat("err2"))
+	HandleExitCoder(err)
+
+	expect(t, called, true)
+	expect(t, ErrWriter.(*bytes.Buffer).String(), "This the format: err1\nThis the format: err2\n")
+}

--- a/vendor/github.com/urfave/cli/flag-types.json
+++ b/vendor/github.com/urfave/cli/flag-types.json
@@ -1,0 +1,93 @@
+[
+  {
+    "name": "Bool",
+    "type": "bool",
+    "value": false,
+    "context_default": "false",
+    "parser": "strconv.ParseBool(f.Value.String())"
+  },
+  {
+    "name": "BoolT",
+    "type": "bool",
+    "value": false,
+    "doctail": " that is true by default",
+    "context_default": "false",
+    "parser": "strconv.ParseBool(f.Value.String())"
+  },
+  {
+    "name": "Duration",
+    "type": "time.Duration",
+    "doctail": " (see https://golang.org/pkg/time/#ParseDuration)",
+    "context_default": "0",
+    "parser": "time.ParseDuration(f.Value.String())"
+  },
+  {
+    "name": "Float64",
+    "type": "float64",
+    "context_default": "0",
+    "parser": "strconv.ParseFloat(f.Value.String(), 64)"
+  },
+  {
+    "name": "Generic",
+    "type": "Generic",
+    "dest": false,
+    "context_default": "nil",
+    "context_type": "interface{}"
+  },
+  {
+    "name": "Int64",
+    "type": "int64",
+    "context_default": "0",
+    "parser": "strconv.ParseInt(f.Value.String(), 0, 64)"
+  },
+  {
+    "name": "Int",
+    "type": "int",
+    "context_default": "0",
+    "parser": "strconv.ParseInt(f.Value.String(), 0, 64)",
+    "parser_cast": "int(parsed)"
+  },
+  {
+    "name": "IntSlice",
+    "type": "*IntSlice",
+    "dest": false,
+    "context_default": "nil",
+    "context_type": "[]int",
+    "parser": "(f.Value.(*IntSlice)).Value(), error(nil)"
+  },
+  {
+    "name": "Int64Slice",
+    "type": "*Int64Slice",
+    "dest": false,
+    "context_default": "nil",
+    "context_type": "[]int64",
+    "parser": "(f.Value.(*Int64Slice)).Value(), error(nil)"
+  },
+  {
+    "name": "String",
+    "type": "string",
+    "context_default": "\"\"",
+    "parser": "f.Value.String(), error(nil)"
+  },
+  {
+    "name": "StringSlice",
+    "type": "*StringSlice",
+    "dest": false,
+    "context_default": "nil",
+    "context_type": "[]string",
+    "parser": "(f.Value.(*StringSlice)).Value(), error(nil)"
+  },
+  {
+    "name": "Uint64",
+    "type": "uint64",
+    "context_default": "0",
+    "parser": "strconv.ParseUint(f.Value.String(), 0, 64)"
+  },
+  {
+    "name": "Uint",
+    "type": "uint",
+    "context_default": "0",
+    "parser": "strconv.ParseUint(f.Value.String(), 0, 64)",
+    "parser_cast": "uint(parsed)"
+  }
+]

--- a/vendor/github.com/urfave/cli/flag.go
+++ b/vendor/github.com/urfave/cli/flag.go
@@ -1,0 +1,799 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const defaultPlaceholder = "value"
+
+// BashCompletionFlag enables bash-completion for all commands and subcommands
+var BashCompletionFlag = BoolFlag{
+	Name:   "generate-bash-completion",
+	Hidden: true,
+}
+
+// VersionFlag prints the version for the application
+var VersionFlag = BoolFlag{
+	Name:  "version, v",
+	Usage: "print the version",
+}
+
+// HelpFlag prints the help for all commands and subcommands
+// Set to the zero value (BoolFlag{}) to disable flag -- keeps subcommand
+// unless HideHelp is set to true)
+var HelpFlag = BoolFlag{
+	Name:  "help, h",
+	Usage: "show help",
+}
+
+// FlagStringer converts a flag definition to a string. This is used by help
+// to display a flag.
+var FlagStringer FlagStringFunc = stringifyFlag
+
+// FlagsByName is a slice of Flag.
+type FlagsByName []Flag
+
+func (f FlagsByName) Len() int {
+	return len(f)
+}
+
+func (f FlagsByName) Less(i, j int) bool {
+	return f[i].GetName() < f[j].GetName()
+}
+
+func (f FlagsByName) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+// Flag is a common interface related to parsing flags in cli.
+// For more advanced flag parsing techniques, it is recommended that
+// this interface be implemented.
+type Flag interface {
+	fmt.Stringer
+	// Apply Flag settings to the given flag set
+	Apply(*flag.FlagSet)
+	GetName() string
+}
+
+// errorableFlag is an interface that allows us to return errors during apply
+// it allows flags defined in this library to return errors in a fashion backwards compatible
+// TODO remove in v2 and modify the existing Flag interface to return errors
+type errorableFlag interface {
+	Flag
+
+	ApplyWithError(*flag.FlagSet) error
+}
+
+func flagSet(name string, flags []Flag) (*flag.FlagSet, error) {
+	set := flag.NewFlagSet(name, flag.ContinueOnError)
+
+	for _, f := range flags {
+		//TODO remove in v2 when errorableFlag is removed
+		if ef, ok := f.(errorableFlag); ok {
+			if err := ef.ApplyWithError(set); err != nil {
+				return nil, err
+			}
+		} else {
+			f.Apply(set)
+		}
+	}
+	return set, nil
+}
+
+func eachName(longName string, fn func(string)) {
+	parts := strings.Split(longName, ",")
+	for _, name := range parts {
+		name = strings.Trim(name, " ")
+		fn(name)
+	}
+}
+
+// Generic is a generic parseable type identified by a specific flag
+type Generic interface {
+	Set(value string) error
+	String() string
+}
+
+// Apply takes the flagset and calls Set on the generic flag with the value
+// provided by the user for parsing by the flag
+// Ignores parsing errors
+func (f GenericFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError takes the flagset and calls Set on the generic flag with the value
+// provided by the user for parsing by the flag
+func (f GenericFlag) ApplyWithError(set *flag.FlagSet) error {
+	val := f.Value
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				if err := val.Set(envVal); err != nil {
+					return fmt.Errorf("could not parse %s as value for flag %s: %s", envVal, f.Name, err)
+				}
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		set.Var(f.Value, name, f.Usage)
+	})
+
+	return nil
+}
+
+// StringSlice is an opaque type for []string to satisfy flag.Value and flag.Getter
+type StringSlice []string
+
+// Set appends the string value to the list of values
+func (f *StringSlice) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *StringSlice) String() string {
+	return fmt.Sprintf("%s", *f)
+}
+
+// Value returns the slice of strings set by this flag
+func (f *StringSlice) Value() []string {
+	return *f
+}
+
+// Get returns the slice of strings set by this flag
+func (f *StringSlice) Get() interface{} {
+	return *f
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f StringSliceFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f StringSliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				newVal := &StringSlice{}
+				for _, s := range strings.Split(envVal, ",") {
+					s = strings.TrimSpace(s)
+					if err := newVal.Set(s); err != nil {
+						return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
+					}
+				}
+				f.Value = newVal
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &StringSlice{}
+		}
+		set.Var(f.Value, name, f.Usage)
+	})
+
+	return nil
+}
+
+// IntSlice is an opaque type for []int to satisfy flag.Value and flag.Getter
+type IntSlice []int
+
+// Set parses the value into an integer and appends it to the list of values
+func (f *IntSlice) Set(value string) error {
+	tmp, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	*f = append(*f, tmp)
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *IntSlice) String() string {
+	return fmt.Sprintf("%#v", *f)
+}
+
+// Value returns the slice of ints set by this flag
+func (f *IntSlice) Value() []int {
+	return *f
+}
+
+// Get returns the slice of ints set by this flag
+func (f *IntSlice) Get() interface{} {
+	return *f
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f IntSliceFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f IntSliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				newVal := &IntSlice{}
+				for _, s := range strings.Split(envVal, ",") {
+					s = strings.TrimSpace(s)
+					if err := newVal.Set(s); err != nil {
+						return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
+					}
+				}
+				f.Value = newVal
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &IntSlice{}
+		}
+		set.Var(f.Value, name, f.Usage)
+	})
+
+	return nil
+}
+
+// Int64Slice is an opaque type for []int to satisfy flag.Value and flag.Getter
+type Int64Slice []int64
+
+// Set parses the value into an integer and appends it to the list of values
+func (f *Int64Slice) Set(value string) error {
+	tmp, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return err
+	}
+	*f = append(*f, tmp)
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *Int64Slice) String() string {
+	return fmt.Sprintf("%#v", *f)
+}
+
+// Value returns the slice of ints set by this flag
+func (f *Int64Slice) Value() []int64 {
+	return *f
+}
+
+// Get returns the slice of ints set by this flag
+func (f *Int64Slice) Get() interface{} {
+	return *f
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f Int64SliceFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f Int64SliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				newVal := &Int64Slice{}
+				for _, s := range strings.Split(envVal, ",") {
+					s = strings.TrimSpace(s)
+					if err := newVal.Set(s); err != nil {
+						return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
+					}
+				}
+				f.Value = newVal
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &Int64Slice{}
+		}
+		set.Var(f.Value, name, f.Usage)
+	})
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f BoolFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f BoolFlag) ApplyWithError(set *flag.FlagSet) error {
+	val := false
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				if envVal == "" {
+					val = false
+					break
+				}
+
+				envValBool, err := strconv.ParseBool(envVal)
+				if err != nil {
+					return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
+				}
+
+				val = envValBool
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.BoolVar(f.Destination, name, val, f.Usage)
+			return
+		}
+		set.Bool(name, val, f.Usage)
+	})
+
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f BoolTFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f BoolTFlag) ApplyWithError(set *flag.FlagSet) error {
+	val := true
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				if envVal == "" {
+					val = false
+					break
+				}
+
+				envValBool, err := strconv.ParseBool(envVal)
+				if err != nil {
+					return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
+				}
+
+				val = envValBool
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.BoolVar(f.Destination, name, val, f.Usage)
+			return
+		}
+		set.Bool(name, val, f.Usage)
+	})
+
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f StringFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f StringFlag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				f.Value = envVal
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.StringVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.String(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f IntFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f IntFlag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				envValInt, err := strconv.ParseInt(envVal, 0, 64)
+				if err != nil {
+					return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
+				}
+				f.Value = int(envValInt)
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.IntVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Int(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f Int64Flag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f Int64Flag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				envValInt, err := strconv.ParseInt(envVal, 0, 64)
+				if err != nil {
+					return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
+				}
+
+				f.Value = envValInt
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.Int64Var(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Int64(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f UintFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f UintFlag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				envValInt, err := strconv.ParseUint(envVal, 0, 64)
+				if err != nil {
+					return fmt.Errorf("could not parse %s as uint value for flag %s: %s", envVal, f.Name, err)
+				}
+
+				f.Value = uint(envValInt)
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.UintVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Uint(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f Uint64Flag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f Uint64Flag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				envValInt, err := strconv.ParseUint(envVal, 0, 64)
+				if err != nil {
+					return fmt.Errorf("could not parse %s as uint64 value for flag %s: %s", envVal, f.Name, err)
+				}
+
+				f.Value = uint64(envValInt)
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.Uint64Var(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Uint64(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f DurationFlag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f DurationFlag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				envValDuration, err := time.ParseDuration(envVal)
+				if err != nil {
+					return fmt.Errorf("could not parse %s as duration for flag %s: %s", envVal, f.Name, err)
+				}
+
+				f.Value = envValDuration
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.DurationVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Duration(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f Float64Flag) Apply(set *flag.FlagSet) {
+	f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f Float64Flag) ApplyWithError(set *flag.FlagSet) error {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal, ok := syscall.Getenv(envVar); ok {
+				envValFloat, err := strconv.ParseFloat(envVal, 10)
+				if err != nil {
+					return fmt.Errorf("could not parse %s as float64 value for flag %s: %s", envVal, f.Name, err)
+				}
+
+				f.Value = float64(envValFloat)
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.Float64Var(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Float64(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+func visibleFlags(fl []Flag) []Flag {
+	visible := []Flag{}
+	for _, flag := range fl {
+		if !flagValue(flag).FieldByName("Hidden").Bool() {
+			visible = append(visible, flag)
+		}
+	}
+	return visible
+}
+
+func prefixFor(name string) (prefix string) {
+	if len(name) == 1 {
+		prefix = "-"
+	} else {
+		prefix = "--"
+	}
+
+	return
+}
+
+// Returns the placeholder, if any, and the unquoted usage string.
+func unquoteUsage(usage string) (string, string) {
+	for i := 0; i < len(usage); i++ {
+		if usage[i] == '`' {
+			for j := i + 1; j < len(usage); j++ {
+				if usage[j] == '`' {
+					name := usage[i+1 : j]
+					usage = usage[:i] + name + usage[j+1:]
+					return name, usage
+				}
+			}
+			break
+		}
+	}
+	return "", usage
+}
+
+func prefixedNames(fullName, placeholder string) string {
+	var prefixed string
+	parts := strings.Split(fullName, ",")
+	for i, name := range parts {
+		name = strings.Trim(name, " ")
+		prefixed += prefixFor(name) + name
+		if placeholder != "" {
+			prefixed += " " + placeholder
+		}
+		if i < len(parts)-1 {
+			prefixed += ", "
+		}
+	}
+	return prefixed
+}
+
+func withEnvHint(envVar, str string) string {
+	envText := ""
+	if envVar != "" {
+		prefix := "$"
+		suffix := ""
+		sep := ", $"
+		if runtime.GOOS == "windows" {
+			prefix = "%"
+			suffix = "%"
+			sep = "%, %"
+		}
+		envText = fmt.Sprintf(" [%s%s%s]", prefix, strings.Join(strings.Split(envVar, ","), sep), suffix)
+	}
+	return str + envText
+}
+
+func flagValue(f Flag) reflect.Value {
+	fv := reflect.ValueOf(f)
+	for fv.Kind() == reflect.Ptr {
+		fv = reflect.Indirect(fv)
+	}
+	return fv
+}
+
+func stringifyFlag(f Flag) string {
+	fv := flagValue(f)
+
+	switch f.(type) {
+	case IntSliceFlag:
+		return withEnvHint(fv.FieldByName("EnvVar").String(),
+			stringifyIntSliceFlag(f.(IntSliceFlag)))
+	case Int64SliceFlag:
+		return withEnvHint(fv.FieldByName("EnvVar").String(),
+			stringifyInt64SliceFlag(f.(Int64SliceFlag)))
+	case StringSliceFlag:
+		return withEnvHint(fv.FieldByName("EnvVar").String(),
+			stringifyStringSliceFlag(f.(StringSliceFlag)))
+	}
+
+	placeholder, usage := unquoteUsage(fv.FieldByName("Usage").String())
+
+	needsPlaceholder := false
+	defaultValueString := ""
+	val := fv.FieldByName("Value")
+
+	if val.IsValid() {
+		needsPlaceholder = true
+		defaultValueString = fmt.Sprintf(" (default: %v)", val.Interface())
+
+		if val.Kind() == reflect.String && val.String() != "" {
+			defaultValueString = fmt.Sprintf(" (default: %q)", val.String())
+		}
+	}
+
+	if defaultValueString == " (default: )" {
+		defaultValueString = ""
+	}
+
+	if needsPlaceholder && placeholder == "" {
+		placeholder = defaultPlaceholder
+	}
+
+	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultValueString))
+
+	return withEnvHint(fv.FieldByName("EnvVar").String(),
+		fmt.Sprintf("%s\t%s", prefixedNames(fv.FieldByName("Name").String(), placeholder), usageWithDefault))
+}
+
+func stringifyIntSliceFlag(f IntSliceFlag) string {
+	defaultVals := []string{}
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, fmt.Sprintf("%d", i))
+		}
+	}
+
+	return stringifySliceFlag(f.Usage, f.Name, defaultVals)
+}
+
+func stringifyInt64SliceFlag(f Int64SliceFlag) string {
+	defaultVals := []string{}
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, fmt.Sprintf("%d", i))
+		}
+	}
+
+	return stringifySliceFlag(f.Usage, f.Name, defaultVals)
+}
+
+func stringifyStringSliceFlag(f StringSliceFlag) string {
+	defaultVals := []string{}
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, s := range f.Value.Value() {
+			if len(s) > 0 {
+				defaultVals = append(defaultVals, fmt.Sprintf("%q", s))
+			}
+		}
+	}
+
+	return stringifySliceFlag(f.Usage, f.Name, defaultVals)
+}
+
+func stringifySliceFlag(usage, name string, defaultVals []string) string {
+	placeholder, usage := unquoteUsage(usage)
+	if placeholder == "" {
+		placeholder = defaultPlaceholder
+	}
+
+	defaultVal := ""
+	if len(defaultVals) > 0 {
+		defaultVal = fmt.Sprintf(" (default: %s)", strings.Join(defaultVals, ", "))
+	}
+
+	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultVal))
+	return fmt.Sprintf("%s\t%s", prefixedNames(name, placeholder), usageWithDefault)
+}

--- a/vendor/github.com/urfave/cli/flag_generated.go
+++ b/vendor/github.com/urfave/cli/flag_generated.go
@@ -1,0 +1,627 @@
+package cli
+
+import (
+	"flag"
+	"strconv"
+	"time"
+)
+
+// WARNING: This file is generated!
+
+// BoolFlag is a flag with type bool
+type BoolFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Hidden      bool
+	Destination *bool
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f BoolFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f BoolFlag) GetName() string {
+	return f.Name
+}
+
+// Bool looks up the value of a local BoolFlag, returns
+// false if not found
+func (c *Context) Bool(name string) bool {
+	return lookupBool(name, c.flagSet)
+}
+
+// GlobalBool looks up the value of a global BoolFlag, returns
+// false if not found
+func (c *Context) GlobalBool(name string) bool {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupBool(name, fs)
+	}
+	return false
+}
+
+func lookupBool(name string, set *flag.FlagSet) bool {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return false
+		}
+		return parsed
+	}
+	return false
+}
+
+// BoolTFlag is a flag with type bool that is true by default
+type BoolTFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Hidden      bool
+	Destination *bool
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f BoolTFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f BoolTFlag) GetName() string {
+	return f.Name
+}
+
+// BoolT looks up the value of a local BoolTFlag, returns
+// false if not found
+func (c *Context) BoolT(name string) bool {
+	return lookupBoolT(name, c.flagSet)
+}
+
+// GlobalBoolT looks up the value of a global BoolTFlag, returns
+// false if not found
+func (c *Context) GlobalBoolT(name string) bool {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupBoolT(name, fs)
+	}
+	return false
+}
+
+func lookupBoolT(name string, set *flag.FlagSet) bool {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return false
+		}
+		return parsed
+	}
+	return false
+}
+
+// DurationFlag is a flag with type time.Duration (see https://golang.org/pkg/time/#ParseDuration)
+type DurationFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Hidden      bool
+	Value       time.Duration
+	Destination *time.Duration
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f DurationFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f DurationFlag) GetName() string {
+	return f.Name
+}
+
+// Duration looks up the value of a local DurationFlag, returns
+// 0 if not found
+func (c *Context) Duration(name string) time.Duration {
+	return lookupDuration(name, c.flagSet)
+}
+
+// GlobalDuration looks up the value of a global DurationFlag, returns
+// 0 if not found
+func (c *Context) GlobalDuration(name string) time.Duration {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupDuration(name, fs)
+	}
+	return 0
+}
+
+func lookupDuration(name string, set *flag.FlagSet) time.Duration {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := time.ParseDuration(f.Value.String())
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}
+
+// Float64Flag is a flag with type float64
+type Float64Flag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Hidden      bool
+	Value       float64
+	Destination *float64
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f Float64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f Float64Flag) GetName() string {
+	return f.Name
+}
+
+// Float64 looks up the value of a local Float64Flag, returns
+// 0 if not found
+func (c *Context) Float64(name string) float64 {
+	return lookupFloat64(name, c.flagSet)
+}
+
+// GlobalFloat64 looks up the value of a global Float64Flag, returns
+// 0 if not found
+func (c *Context) GlobalFloat64(name string) float64 {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupFloat64(name, fs)
+	}
+	return 0
+}
+
+func lookupFloat64(name string, set *flag.FlagSet) float64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseFloat(f.Value.String(), 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}
+
+// GenericFlag is a flag with type Generic
+type GenericFlag struct {
+	Name   string
+	Usage  string
+	EnvVar string
+	Hidden bool
+	Value  Generic
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f GenericFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f GenericFlag) GetName() string {
+	return f.Name
+}
+
+// Generic looks up the value of a local GenericFlag, returns
+// nil if not found
+func (c *Context) Generic(name string) interface{} {
+	return lookupGeneric(name, c.flagSet)
+}
+
+// GlobalGeneric looks up the value of a global GenericFlag, returns
+// nil if not found
+func (c *Context) GlobalGeneric(name string) interface{} {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupGeneric(name, fs)
+	}
+	return nil
+}
+
+func lookupGeneric(name string, set *flag.FlagSet) interface{} {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := f.Value, error(nil)
+		if err != nil {
+			return nil
+		}
+		return parsed
+	}
+	return nil
+}
+
+// Int64Flag is a flag with type int64
+type Int64Flag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Hidden      bool
+	Value       int64
+	Destination *int64
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f Int64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f Int64Flag) GetName() string {
+	return f.Name
+}
+
+// Int64 looks up the value of a local Int64Flag, returns
+// 0 if not found
+func (c *Context) Int64(name string) int64 {
+	return lookupInt64(name, c.flagSet)
+}
+
+// GlobalInt64 looks up the value of a global Int64Flag, returns
+// 0 if not found
+func (c *Context) GlobalInt64(name string) int64 {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupInt64(name, fs)
+	}
+	return 0
+}
+
+func lookupInt64(name string, set *flag.FlagSet) int64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseInt(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}
+
+// IntFlag is a flag with type int
+type IntFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Hidden      bool
+	Value       int
+	Destination *int
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f IntFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f IntFlag) GetName() string {
+	return f.Name
+}
+
+// Int looks up the value of a local IntFlag, returns
+// 0 if not found
+func (c *Context) Int(name string) int {
+	return lookupInt(name, c.flagSet)
+}
+
+// GlobalInt looks up the value of a global IntFlag, returns
+// 0 if not found
+func (c *Context) GlobalInt(name string) int {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupInt(name, fs)
+	}
+	return 0
+}
+
+func lookupInt(name string, set *flag.FlagSet) int {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseInt(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return int(parsed)
+	}
+	return 0
+}
+
+// IntSliceFlag is a flag with type *IntSlice
+type IntSliceFlag struct {
+	Name   string
+	Usage  string
+	EnvVar string
+	Hidden bool
+	Value  *IntSlice
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f IntSliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f IntSliceFlag) GetName() string {
+	return f.Name
+}
+
+// IntSlice looks up the value of a local IntSliceFlag, returns
+// nil if not found
+func (c *Context) IntSlice(name string) []int {
+	return lookupIntSlice(name, c.flagSet)
+}
+
+// GlobalIntSlice looks up the value of a global IntSliceFlag, returns
+// nil if not found
+func (c *Context) GlobalIntSlice(name string) []int {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupIntSlice(name, fs)
+	}
+	return nil
+}
+
+func lookupIntSlice(name string, set *flag.FlagSet) []int {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := (f.Value.(*IntSlice)).Value(), error(nil)
+		if err != nil {
+			return nil
+		}
+		return parsed
+	}
+	return nil
+}
+
+// Int64SliceFlag is a flag with type *Int64Slice
+type Int64SliceFlag struct {
+	Name   string
+	Usage  string
+	EnvVar string
+	Hidden bool
+	Value  *Int64Slice
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f Int64SliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f Int64SliceFlag) GetName() string {
+	return f.Name
+}
+
+// Int64Slice looks up the value of a local Int64SliceFlag, returns
+// nil if not found
+func (c *Context) Int64Slice(name string) []int64 {
+	return lookupInt64Slice(name, c.flagSet)
+}
+
+// GlobalInt64Slice looks up the value of a global Int64SliceFlag, returns
+// nil if not found
+func (c *Context) GlobalInt64Slice(name string) []int64 {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupInt64Slice(name, fs)
+	}
+	return nil
+}
+
+func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := (f.Value.(*Int64Slice)).Value(), error(nil)
+		if err != nil {
+			return nil
+		}
+		return parsed
+	}
+	return nil
+}
+
+// StringFlag is a flag with type string
+type StringFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Hidden      bool
+	Value       string
+	Destination *string
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f StringFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f StringFlag) GetName() string {
+	return f.Name
+}
+
+// String looks up the value of a local StringFlag, returns
+// "" if not found
+func (c *Context) String(name string) string {
+	return lookupString(name, c.flagSet)
+}
+
+// GlobalString looks up the value of a global StringFlag, returns
+// "" if not found
+func (c *Context) GlobalString(name string) string {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupString(name, fs)
+	}
+	return ""
+}
+
+func lookupString(name string, set *flag.FlagSet) string {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := f.Value.String(), error(nil)
+		if err != nil {
+			return ""
+		}
+		return parsed
+	}
+	return ""
+}
+
+// StringSliceFlag is a flag with type *StringSlice
+type StringSliceFlag struct {
+	Name   string
+	Usage  string
+	EnvVar string
+	Hidden bool
+	Value  *StringSlice
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f StringSliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f StringSliceFlag) GetName() string {
+	return f.Name
+}
+
+// StringSlice looks up the value of a local StringSliceFlag, returns
+// nil if not found
+func (c *Context) StringSlice(name string) []string {
+	return lookupStringSlice(name, c.flagSet)
+}
+
+// GlobalStringSlice looks up the value of a global StringSliceFlag, returns
+// nil if not found
+func (c *Context) GlobalStringSlice(name string) []string {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupStringSlice(name, fs)
+	}
+	return nil
+}
+
+func lookupStringSlice(name string, set *flag.FlagSet) []string {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := (f.Value.(*StringSlice)).Value(), error(nil)
+		if err != nil {
+			return nil
+		}
+		return parsed
+	}
+	return nil
+}
+
+// Uint64Flag is a flag with type uint64
+type Uint64Flag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Hidden      bool
+	Value       uint64
+	Destination *uint64
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f Uint64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f Uint64Flag) GetName() string {
+	return f.Name
+}
+
+// Uint64 looks up the value of a local Uint64Flag, returns
+// 0 if not found
+func (c *Context) Uint64(name string) uint64 {
+	return lookupUint64(name, c.flagSet)
+}
+
+// GlobalUint64 looks up the value of a global Uint64Flag, returns
+// 0 if not found
+func (c *Context) GlobalUint64(name string) uint64 {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupUint64(name, fs)
+	}
+	return 0
+}
+
+func lookupUint64(name string, set *flag.FlagSet) uint64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseUint(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}
+
+// UintFlag is a flag with type uint
+type UintFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Hidden      bool
+	Value       uint
+	Destination *uint
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f UintFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f UintFlag) GetName() string {
+	return f.Name
+}
+
+// Uint looks up the value of a local UintFlag, returns
+// 0 if not found
+func (c *Context) Uint(name string) uint {
+	return lookupUint(name, c.flagSet)
+}
+
+// GlobalUint looks up the value of a global UintFlag, returns
+// 0 if not found
+func (c *Context) GlobalUint(name string) uint {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupUint(name, fs)
+	}
+	return 0
+}
+
+func lookupUint(name string, set *flag.FlagSet) uint {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseUint(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return uint(parsed)
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/flag_test.go
+++ b/vendor/github.com/urfave/cli/flag_test.go
@@ -1,0 +1,1203 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+var boolFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"help", "--help\t"},
+	{"h", "-h\t"},
+}
+
+func TestBoolFlagHelpOutput(t *testing.T) {
+	for _, test := range boolFlagTests {
+		flag := BoolFlag{Name: test.name}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestFlagsFromEnv(t *testing.T) {
+	var flagTests = []struct {
+		input  string
+		output interface{}
+		flag   Flag
+		err    error
+	}{
+		{"", false, BoolFlag{Name: "debug", EnvVar: "DEBUG"}, nil},
+		{"1", true, BoolFlag{Name: "debug", EnvVar: "DEBUG"}, nil},
+		{"false", false, BoolFlag{Name: "debug", EnvVar: "DEBUG"}, nil},
+		{"foobar", true, BoolFlag{Name: "debug", EnvVar: "DEBUG"}, fmt.Errorf(`could not parse foobar as bool value for flag debug: strconv.ParseBool: parsing "foobar": invalid syntax`)},
+
+		{"", false, BoolTFlag{Name: "debug", EnvVar: "DEBUG"}, nil},
+		{"1", true, BoolTFlag{Name: "debug", EnvVar: "DEBUG"}, nil},
+		{"false", false, BoolTFlag{Name: "debug", EnvVar: "DEBUG"}, nil},
+		{"foobar", true, BoolTFlag{Name: "debug", EnvVar: "DEBUG"}, fmt.Errorf(`could not parse foobar as bool value for flag debug: strconv.ParseBool: parsing "foobar": invalid syntax`)},
+
+		{"1s", 1 * time.Second, DurationFlag{Name: "time", EnvVar: "TIME"}, nil},
+		{"foobar", false, DurationFlag{Name: "time", EnvVar: "TIME"}, fmt.Errorf(`could not parse foobar as duration for flag time: time: invalid duration foobar`)},
+
+		{"1.2", 1.2, Float64Flag{Name: "seconds", EnvVar: "SECONDS"}, nil},
+		{"1", 1.0, Float64Flag{Name: "seconds", EnvVar: "SECONDS"}, nil},
+		{"foobar", 0, Float64Flag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse foobar as float64 value for flag seconds: strconv.ParseFloat: parsing "foobar": invalid syntax`)},
+
+		{"1", int64(1), Int64Flag{Name: "seconds", EnvVar: "SECONDS"}, nil},
+		{"1.2", 0, Int64Flag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse 1.2 as int value for flag seconds: strconv.ParseInt: parsing "1.2": invalid syntax`)},
+		{"foobar", 0, Int64Flag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse foobar as int value for flag seconds: strconv.ParseInt: parsing "foobar": invalid syntax`)},
+
+		{"1", 1, IntFlag{Name: "seconds", EnvVar: "SECONDS"}, nil},
+		{"1.2", 0, IntFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse 1.2 as int value for flag seconds: strconv.ParseInt: parsing "1.2": invalid syntax`)},
+		{"foobar", 0, IntFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse foobar as int value for flag seconds: strconv.ParseInt: parsing "foobar": invalid syntax`)},
+
+		{"1,2", IntSlice{1, 2}, IntSliceFlag{Name: "seconds", EnvVar: "SECONDS"}, nil},
+		{"1.2,2", IntSlice{}, IntSliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse 1.2,2 as int slice value for flag seconds: strconv.ParseInt: parsing "1.2": invalid syntax`)},
+		{"foobar", IntSlice{}, IntSliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse foobar as int slice value for flag seconds: strconv.ParseInt: parsing "foobar": invalid syntax`)},
+
+		{"1,2", Int64Slice{1, 2}, Int64SliceFlag{Name: "seconds", EnvVar: "SECONDS"}, nil},
+		{"1.2,2", Int64Slice{}, Int64SliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse 1.2,2 as int64 slice value for flag seconds: strconv.ParseInt: parsing "1.2": invalid syntax`)},
+		{"foobar", Int64Slice{}, Int64SliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse foobar as int64 slice value for flag seconds: strconv.ParseInt: parsing "foobar": invalid syntax`)},
+
+		{"foo", "foo", StringFlag{Name: "name", EnvVar: "NAME"}, nil},
+
+		{"foo,bar", StringSlice{"foo", "bar"}, StringSliceFlag{Name: "names", EnvVar: "NAMES"}, nil},
+
+		{"1", uint(1), UintFlag{Name: "seconds", EnvVar: "SECONDS"}, nil},
+		{"1.2", 0, UintFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse 1.2 as uint value for flag seconds: strconv.ParseUint: parsing "1.2": invalid syntax`)},
+		{"foobar", 0, UintFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse foobar as uint value for flag seconds: strconv.ParseUint: parsing "foobar": invalid syntax`)},
+
+		{"1", uint64(1), Uint64Flag{Name: "seconds", EnvVar: "SECONDS"}, nil},
+		{"1.2", 0, Uint64Flag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse 1.2 as uint64 value for flag seconds: strconv.ParseUint: parsing "1.2": invalid syntax`)},
+		{"foobar", 0, Uint64Flag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Errorf(`could not parse foobar as uint64 value for flag seconds: strconv.ParseUint: parsing "foobar": invalid syntax`)},
+
+		{"foo,bar", &Parser{"foo", "bar"}, GenericFlag{Name: "names", Value: &Parser{}, EnvVar: "NAMES"}, nil},
+	}
+
+	for _, test := range flagTests {
+		os.Clearenv()
+		os.Setenv(reflect.ValueOf(test.flag).FieldByName("EnvVar").String(), test.input)
+		a := App{
+			Flags: []Flag{test.flag},
+			Action: func(ctx *Context) error {
+				if !reflect.DeepEqual(ctx.value(test.flag.GetName()), test.output) {
+					t.Errorf("expected %+v to be parsed as %+v, instead was %+v", test.input, test.output, ctx.value(test.flag.GetName()))
+				}
+				return nil
+			},
+		}
+
+		err := a.Run([]string{"run"})
+		if !reflect.DeepEqual(test.err, err) {
+			t.Errorf("expected error %s, got error %s", test.err, err)
+		}
+	}
+}
+
+var stringFlagTests = []struct {
+	name     string
+	usage    string
+	value    string
+	expected string
+}{
+	{"foo", "", "", "--foo value\t"},
+	{"f", "", "", "-f value\t"},
+	{"f", "The total `foo` desired", "all", "-f foo\tThe total foo desired (default: \"all\")"},
+	{"test", "", "Something", "--test value\t(default: \"Something\")"},
+	{"config,c", "Load configuration from `FILE`", "", "--config FILE, -c FILE\tLoad configuration from FILE"},
+	{"config,c", "Load configuration from `CONFIG`", "config.json", "--config CONFIG, -c CONFIG\tLoad configuration from CONFIG (default: \"config.json\")"},
+}
+
+func TestStringFlagHelpOutput(t *testing.T) {
+	for _, test := range stringFlagTests {
+		flag := StringFlag{Name: test.name, Usage: test.usage, Value: test.value}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestStringFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_FOO", "derp")
+	for _, test := range stringFlagTests {
+		flag := StringFlag{Name: test.name, Value: test.value, EnvVar: "APP_FOO"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_FOO]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_FOO%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%s does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var stringSliceFlagTests = []struct {
+	name     string
+	value    *StringSlice
+	expected string
+}{
+	{"foo", func() *StringSlice {
+		s := &StringSlice{}
+		s.Set("")
+		return s
+	}(), "--foo value\t"},
+	{"f", func() *StringSlice {
+		s := &StringSlice{}
+		s.Set("")
+		return s
+	}(), "-f value\t"},
+	{"f", func() *StringSlice {
+		s := &StringSlice{}
+		s.Set("Lipstick")
+		return s
+	}(), "-f value\t(default: \"Lipstick\")"},
+	{"test", func() *StringSlice {
+		s := &StringSlice{}
+		s.Set("Something")
+		return s
+	}(), "--test value\t(default: \"Something\")"},
+}
+
+func TestStringSliceFlagHelpOutput(t *testing.T) {
+	for _, test := range stringSliceFlagTests {
+		flag := StringSliceFlag{Name: test.name, Value: test.value}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestStringSliceFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_QWWX", "11,4")
+	for _, test := range stringSliceFlagTests {
+		flag := StringSliceFlag{Name: test.name, Value: test.value, EnvVar: "APP_QWWX"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_QWWX]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_QWWX%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%q does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var intFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"hats", "--hats value\t(default: 9)"},
+	{"H", "-H value\t(default: 9)"},
+}
+
+func TestIntFlagHelpOutput(t *testing.T) {
+	for _, test := range intFlagTests {
+		flag := IntFlag{Name: test.name, Value: 9}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+func TestIntFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_BAR", "2")
+	for _, test := range intFlagTests {
+		flag := IntFlag{Name: test.name, EnvVar: "APP_BAR"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_BAR]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_BAR%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%s does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var int64FlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"hats", "--hats value\t(default: 8589934592)"},
+	{"H", "-H value\t(default: 8589934592)"},
+}
+
+func TestInt64FlagHelpOutput(t *testing.T) {
+	for _, test := range int64FlagTests {
+		flag := Int64Flag{Name: test.name, Value: 8589934592}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+func TestInt64FlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_BAR", "2")
+	for _, test := range int64FlagTests {
+		flag := IntFlag{Name: test.name, EnvVar: "APP_BAR"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_BAR]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_BAR%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%s does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var uintFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"nerfs", "--nerfs value\t(default: 41)"},
+	{"N", "-N value\t(default: 41)"},
+}
+
+func TestUintFlagHelpOutput(t *testing.T) {
+	for _, test := range uintFlagTests {
+		flag := UintFlag{Name: test.name, Value: 41}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+func TestUintFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_BAR", "2")
+	for _, test := range uintFlagTests {
+		flag := UintFlag{Name: test.name, EnvVar: "APP_BAR"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_BAR]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_BAR%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%s does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var uint64FlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"gerfs", "--gerfs value\t(default: 8589934582)"},
+	{"G", "-G value\t(default: 8589934582)"},
+}
+
+func TestUint64FlagHelpOutput(t *testing.T) {
+	for _, test := range uint64FlagTests {
+		flag := Uint64Flag{Name: test.name, Value: 8589934582}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+func TestUint64FlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_BAR", "2")
+	for _, test := range uint64FlagTests {
+		flag := UintFlag{Name: test.name, EnvVar: "APP_BAR"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_BAR]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_BAR%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%s does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var durationFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"hooting", "--hooting value\t(default: 1s)"},
+	{"H", "-H value\t(default: 1s)"},
+}
+
+func TestDurationFlagHelpOutput(t *testing.T) {
+	for _, test := range durationFlagTests {
+		flag := DurationFlag{Name: test.name, Value: 1 * time.Second}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestDurationFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_BAR", "2h3m6s")
+	for _, test := range durationFlagTests {
+		flag := DurationFlag{Name: test.name, EnvVar: "APP_BAR"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_BAR]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_BAR%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%s does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var intSliceFlagTests = []struct {
+	name     string
+	value    *IntSlice
+	expected string
+}{
+	{"heads", &IntSlice{}, "--heads value\t"},
+	{"H", &IntSlice{}, "-H value\t"},
+	{"H, heads", func() *IntSlice {
+		i := &IntSlice{}
+		i.Set("9")
+		i.Set("3")
+		return i
+	}(), "-H value, --heads value\t(default: 9, 3)"},
+}
+
+func TestIntSliceFlagHelpOutput(t *testing.T) {
+	for _, test := range intSliceFlagTests {
+		flag := IntSliceFlag{Name: test.name, Value: test.value}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestIntSliceFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_SMURF", "42,3")
+	for _, test := range intSliceFlagTests {
+		flag := IntSliceFlag{Name: test.name, Value: test.value, EnvVar: "APP_SMURF"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_SMURF]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_SMURF%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%q does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var int64SliceFlagTests = []struct {
+	name     string
+	value    *Int64Slice
+	expected string
+}{
+	{"heads", &Int64Slice{}, "--heads value\t"},
+	{"H", &Int64Slice{}, "-H value\t"},
+	{"H, heads", func() *Int64Slice {
+		i := &Int64Slice{}
+		i.Set("2")
+		i.Set("17179869184")
+		return i
+	}(), "-H value, --heads value\t(default: 2, 17179869184)"},
+}
+
+func TestInt64SliceFlagHelpOutput(t *testing.T) {
+	for _, test := range int64SliceFlagTests {
+		flag := Int64SliceFlag{Name: test.name, Value: test.value}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestInt64SliceFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_SMURF", "42,17179869184")
+	for _, test := range int64SliceFlagTests {
+		flag := Int64SliceFlag{Name: test.name, Value: test.value, EnvVar: "APP_SMURF"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_SMURF]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_SMURF%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%q does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var float64FlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"hooting", "--hooting value\t(default: 0.1)"},
+	{"H", "-H value\t(default: 0.1)"},
+}
+
+func TestFloat64FlagHelpOutput(t *testing.T) {
+	for _, test := range float64FlagTests {
+		flag := Float64Flag{Name: test.name, Value: float64(0.1)}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestFloat64FlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_BAZ", "99.4")
+	for _, test := range float64FlagTests {
+		flag := Float64Flag{Name: test.name, EnvVar: "APP_BAZ"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_BAZ]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_BAZ%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%s does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+var genericFlagTests = []struct {
+	name     string
+	value    Generic
+	expected string
+}{
+	{"toads", &Parser{"abc", "def"}, "--toads value\ttest flag (default: abc,def)"},
+	{"t", &Parser{"abc", "def"}, "-t value\ttest flag (default: abc,def)"},
+}
+
+func TestGenericFlagHelpOutput(t *testing.T) {
+	for _, test := range genericFlagTests {
+		flag := GenericFlag{Name: test.name, Value: test.value, Usage: "test flag"}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestGenericFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_ZAP", "3")
+	for _, test := range genericFlagTests {
+		flag := GenericFlag{Name: test.name, EnvVar: "APP_ZAP"}
+		output := flag.String()
+
+		expectedSuffix := " [$APP_ZAP]"
+		if runtime.GOOS == "windows" {
+			expectedSuffix = " [%APP_ZAP%]"
+		}
+		if !strings.HasSuffix(output, expectedSuffix) {
+			t.Errorf("%s does not end with"+expectedSuffix, output)
+		}
+	}
+}
+
+func TestParseMultiString(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			StringFlag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.String("serve") != "10" {
+				t.Errorf("main name not set")
+			}
+			if ctx.String("s") != "10" {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "10"})
+}
+
+func TestParseDestinationString(t *testing.T) {
+	var dest string
+	a := App{
+		Flags: []Flag{
+			StringFlag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) error {
+			if dest != "10" {
+				t.Errorf("expected destination String 10")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "--dest", "10"})
+}
+
+func TestParseMultiStringFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_COUNT", "20")
+	(&App{
+		Flags: []Flag{
+			StringFlag{Name: "count, c", EnvVar: "APP_COUNT"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.String("count") != "20" {
+				t.Errorf("main name not set")
+			}
+			if ctx.String("c") != "20" {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiStringFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_COUNT", "20")
+	(&App{
+		Flags: []Flag{
+			StringFlag{Name: "count, c", EnvVar: "COMPAT_COUNT,APP_COUNT"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.String("count") != "20" {
+				t.Errorf("main name not set")
+			}
+			if ctx.String("c") != "20" {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiStringSlice(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			StringSliceFlag{Name: "serve, s", Value: &StringSlice{}},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.StringSlice("serve"), []string{"10", "20"}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.StringSlice("s"), []string{"10", "20"}) {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "10", "-s", "20"})
+}
+
+func TestParseMultiStringSliceFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,40")
+
+	(&App{
+		Flags: []Flag{
+			StringSliceFlag{Name: "intervals, i", Value: &StringSlice{}, EnvVar: "APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.StringSlice("i"), []string{"20", "30", "40"}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiStringSliceFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,40")
+
+	(&App{
+		Flags: []Flag{
+			StringSliceFlag{Name: "intervals, i", Value: &StringSlice{}, EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.StringSlice("i"), []string{"20", "30", "40"}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiInt(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			IntFlag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Int("serve") != 10 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Int("s") != 10 {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "-s", "10"})
+}
+
+func TestParseDestinationInt(t *testing.T) {
+	var dest int
+	a := App{
+		Flags: []Flag{
+			IntFlag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) error {
+			if dest != 10 {
+				t.Errorf("expected destination Int 10")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "--dest", "10"})
+}
+
+func TestParseMultiIntFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "10")
+	a := App{
+		Flags: []Flag{
+			IntFlag{Name: "timeout, t", EnvVar: "APP_TIMEOUT_SECONDS"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Int("timeout") != 10 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Int("t") != 10 {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiIntFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "10")
+	a := App{
+		Flags: []Flag{
+			IntFlag{Name: "timeout, t", EnvVar: "COMPAT_TIMEOUT_SECONDS,APP_TIMEOUT_SECONDS"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Int("timeout") != 10 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Int("t") != 10 {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiIntSlice(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			IntSliceFlag{Name: "serve, s", Value: &IntSlice{}},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.IntSlice("serve"), []int{10, 20}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.IntSlice("s"), []int{10, 20}) {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "10", "-s", "20"})
+}
+
+func TestParseMultiIntSliceFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,40")
+
+	(&App{
+		Flags: []Flag{
+			IntSliceFlag{Name: "intervals, i", Value: &IntSlice{}, EnvVar: "APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.IntSlice("i"), []int{20, 30, 40}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiIntSliceFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,40")
+
+	(&App{
+		Flags: []Flag{
+			IntSliceFlag{Name: "intervals, i", Value: &IntSlice{}, EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.IntSlice("i"), []int{20, 30, 40}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiInt64Slice(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			Int64SliceFlag{Name: "serve, s", Value: &Int64Slice{}},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Int64Slice("serve"), []int64{10, 17179869184}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.Int64Slice("s"), []int64{10, 17179869184}) {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "10", "-s", "17179869184"})
+}
+
+func TestParseMultiInt64SliceFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,17179869184")
+
+	(&App{
+		Flags: []Flag{
+			Int64SliceFlag{Name: "intervals, i", Value: &Int64Slice{}, EnvVar: "APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Int64Slice("intervals"), []int64{20, 30, 17179869184}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.Int64Slice("i"), []int64{20, 30, 17179869184}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiInt64SliceFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,17179869184")
+
+	(&App{
+		Flags: []Flag{
+			Int64SliceFlag{Name: "intervals, i", Value: &Int64Slice{}, EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Int64Slice("intervals"), []int64{20, 30, 17179869184}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.Int64Slice("i"), []int64{20, 30, 17179869184}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiFloat64(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			Float64Flag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Float64("serve") != 10.2 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Float64("s") != 10.2 {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "-s", "10.2"})
+}
+
+func TestParseDestinationFloat64(t *testing.T) {
+	var dest float64
+	a := App{
+		Flags: []Flag{
+			Float64Flag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) error {
+			if dest != 10.2 {
+				t.Errorf("expected destination Float64 10.2")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "--dest", "10.2"})
+}
+
+func TestParseMultiFloat64FromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "15.5")
+	a := App{
+		Flags: []Flag{
+			Float64Flag{Name: "timeout, t", EnvVar: "APP_TIMEOUT_SECONDS"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Float64("timeout") != 15.5 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Float64("t") != 15.5 {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiFloat64FromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "15.5")
+	a := App{
+		Flags: []Flag{
+			Float64Flag{Name: "timeout, t", EnvVar: "COMPAT_TIMEOUT_SECONDS,APP_TIMEOUT_SECONDS"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Float64("timeout") != 15.5 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Float64("t") != 15.5 {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiBool(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			BoolFlag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Bool("serve") != true {
+				t.Errorf("main name not set")
+			}
+			if ctx.Bool("s") != true {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "--serve"})
+}
+
+func TestParseDestinationBool(t *testing.T) {
+	var dest bool
+	a := App{
+		Flags: []Flag{
+			BoolFlag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) error {
+			if dest != true {
+				t.Errorf("expected destination Bool true")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "--dest"})
+}
+
+func TestParseMultiBoolFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_DEBUG", "1")
+	a := App{
+		Flags: []Flag{
+			BoolFlag{Name: "debug, d", EnvVar: "APP_DEBUG"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Bool("debug") != true {
+				t.Errorf("main name not set from env")
+			}
+			if ctx.Bool("d") != true {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiBoolFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_DEBUG", "1")
+	a := App{
+		Flags: []Flag{
+			BoolFlag{Name: "debug, d", EnvVar: "COMPAT_DEBUG,APP_DEBUG"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Bool("debug") != true {
+				t.Errorf("main name not set from env")
+			}
+			if ctx.Bool("d") != true {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseBoolTFromEnv(t *testing.T) {
+	var boolTFlagTests = []struct {
+		input  string
+		output bool
+	}{
+		{"", false},
+		{"1", true},
+		{"false", false},
+		{"true", true},
+	}
+
+	for _, test := range boolTFlagTests {
+		os.Clearenv()
+		os.Setenv("DEBUG", test.input)
+		a := App{
+			Flags: []Flag{
+				BoolTFlag{Name: "debug, d", EnvVar: "DEBUG"},
+			},
+			Action: func(ctx *Context) error {
+				if ctx.Bool("debug") != test.output {
+					t.Errorf("expected %+v to be parsed as %+v, instead was %+v", test.input, test.output, ctx.Bool("debug"))
+				}
+				if ctx.Bool("d") != test.output {
+					t.Errorf("expected %+v to be parsed as %+v, instead was %+v", test.input, test.output, ctx.Bool("d"))
+				}
+				return nil
+			},
+		}
+		a.Run([]string{"run"})
+	}
+}
+
+func TestParseMultiBoolT(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			BoolTFlag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.BoolT("serve") != true {
+				t.Errorf("main name not set")
+			}
+			if ctx.BoolT("s") != true {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "--serve"})
+}
+
+func TestParseDestinationBoolT(t *testing.T) {
+	var dest bool
+	a := App{
+		Flags: []Flag{
+			BoolTFlag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) error {
+			if dest != true {
+				t.Errorf("expected destination BoolT true")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "--dest"})
+}
+
+func TestParseMultiBoolTFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_DEBUG", "0")
+	a := App{
+		Flags: []Flag{
+			BoolTFlag{Name: "debug, d", EnvVar: "APP_DEBUG"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.BoolT("debug") != false {
+				t.Errorf("main name not set from env")
+			}
+			if ctx.BoolT("d") != false {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiBoolTFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_DEBUG", "0")
+	a := App{
+		Flags: []Flag{
+			BoolTFlag{Name: "debug, d", EnvVar: "COMPAT_DEBUG,APP_DEBUG"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.BoolT("debug") != false {
+				t.Errorf("main name not set from env")
+			}
+			if ctx.BoolT("d") != false {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+type Parser [2]string
+
+func (p *Parser) Set(value string) error {
+	parts := strings.Split(value, ",")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid format")
+	}
+
+	(*p)[0] = parts[0]
+	(*p)[1] = parts[1]
+
+	return nil
+}
+
+func (p *Parser) String() string {
+	return fmt.Sprintf("%s,%s", p[0], p[1])
+}
+
+func (p *Parser) Get() interface{} {
+	return p
+}
+
+func TestParseGeneric(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			GenericFlag{Name: "serve, s", Value: &Parser{}},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Generic("serve"), &Parser{"10", "20"}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.Generic("s"), &Parser{"10", "20"}) {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run", "-s", "10,20"})
+}
+
+func TestParseGenericFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_SERVE", "20,30")
+	a := App{
+		Flags: []Flag{
+			GenericFlag{Name: "serve, s", Value: &Parser{}, EnvVar: "APP_SERVE"},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Generic("serve"), &Parser{"20", "30"}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.Generic("s"), &Parser{"20", "30"}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseGenericFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_FOO", "99,2000")
+	a := App{
+		Flags: []Flag{
+			GenericFlag{Name: "foos", Value: &Parser{}, EnvVar: "COMPAT_FOO,APP_FOO"},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Generic("foos"), &Parser{"99", "2000"}) {
+				t.Errorf("value not set from env")
+			}
+			return nil
+		},
+	}
+	a.Run([]string{"run"})
+}

--- a/vendor/github.com/urfave/cli/funcs.go
+++ b/vendor/github.com/urfave/cli/funcs.go
@@ -1,0 +1,28 @@
+package cli
+
+// BashCompleteFunc is an action to execute when the bash-completion flag is set
+type BashCompleteFunc func(*Context)
+
+// BeforeFunc is an action to execute before any subcommands are run, but after
+// the context is ready if a non-nil error is returned, no subcommands are run
+type BeforeFunc func(*Context) error
+
+// AfterFunc is an action to execute after any subcommands are run, but after the
+// subcommand has finished it is run even if Action() panics
+type AfterFunc func(*Context) error
+
+// ActionFunc is the action to execute when no subcommands are specified
+type ActionFunc func(*Context) error
+
+// CommandNotFoundFunc is executed if the proper command cannot be found
+type CommandNotFoundFunc func(*Context, string)
+
+// OnUsageErrorFunc is executed if an usage error occurs. This is useful for displaying
+// customized usage error messages.  This function is able to replace the
+// original error messages.  If this function is not set, the "Incorrect usage"
+// is displayed and the execution is interrupted.
+type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
+
+// FlagStringFunc is used by the help generation to display a flag, which is
+// expected to be a single line.
+type FlagStringFunc func(Flag) string

--- a/vendor/github.com/urfave/cli/generate-flag-types
+++ b/vendor/github.com/urfave/cli/generate-flag-types
@@ -1,0 +1,255 @@
+#!/usr/bin/env python
+"""
+The flag types that ship with the cli library have many things in common, and
+so we can take advantage of the `go generate` command to create much of the
+source code from a list of definitions.  These definitions attempt to cover
+the parts that vary between flag types, and should evolve as needed.
+
+An example of the minimum definition needed is:
+
+    {
+      "name": "SomeType",
+      "type": "sometype",
+      "context_default": "nil"
+    }
+
+In this example, the code generated for the `cli` package will include a type
+named `SomeTypeFlag` that is expected to wrap a value of type `sometype`.
+Fetching values by name via `*cli.Context` will default to a value of `nil`.
+
+A more complete, albeit somewhat redundant, example showing all available
+definition keys is:
+
+    {
+      "name": "VeryMuchType",
+      "type": "*VeryMuchType",
+      "value": true,
+      "dest": false,
+      "doctail": " which really only wraps a []float64, oh well!",
+      "context_type": "[]float64",
+      "context_default": "nil",
+      "parser": "parseVeryMuchType(f.Value.String())",
+      "parser_cast": "[]float64(parsed)"
+    }
+
+The meaning of each field is as follows:
+
+               name (string) - The type "name", which will be suffixed with
+                               `Flag` when generating the type definition
+                               for `cli` and the wrapper type for `altsrc`
+               type (string) - The type that the generated `Flag` type for `cli`
+                               is expected to "contain" as its `.Value` member
+                value (bool) - Should the generated `cli` type have a `Value`
+                               member?
+                 dest (bool) - Should the generated `cli` type support a
+                               destination pointer?
+            doctail (string) - Additional docs for the `cli` flag type comment
+       context_type (string) - The literal type used in the `*cli.Context`
+                               reader func signature
+    context_default (string) - The literal value used as the default by the
+                               `*cli.Context` reader funcs when no value is
+                               present
+             parser (string) - Literal code used to parse the flag `f`,
+                               expected to have a return signature of
+                               (value, error)
+        parser_cast (string) - Literal code used to cast the `parsed` value
+                               returned from the `parser` code
+"""
+
+from __future__ import print_function, unicode_literals
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+
+class _FancyFormatter(argparse.ArgumentDefaultsHelpFormatter,
+                      argparse.RawDescriptionHelpFormatter):
+    pass
+
+
+def main(sysargs=sys.argv[:]):
+    parser = argparse.ArgumentParser(
+        description='Generate flag type code!',
+        formatter_class=_FancyFormatter)
+    parser.add_argument(
+        'package',
+        type=str, default='cli', choices=_WRITEFUNCS.keys(),
+        help='Package for which flag types will be generated'
+    )
+    parser.add_argument(
+        '-i', '--in-json',
+        type=argparse.FileType('r'),
+        default=sys.stdin,
+        help='Input JSON file which defines each type to be generated'
+    )
+    parser.add_argument(
+        '-o', '--out-go',
+        type=argparse.FileType('w'),
+        default=sys.stdout,
+        help='Output file/stream to which generated source will be written'
+    )
+    parser.epilog = __doc__
+
+    args = parser.parse_args(sysargs[1:])
+    _generate_flag_types(_WRITEFUNCS[args.package], args.out_go, args.in_json)
+    return 0
+
+
+def _generate_flag_types(writefunc, output_go, input_json):
+    types = json.load(input_json)
+
+    tmp = tempfile.NamedTemporaryFile(suffix='.go', delete=False)
+    writefunc(tmp, types)
+    tmp.close()
+
+    new_content = subprocess.check_output(
+        ['goimports', tmp.name]
+    ).decode('utf-8')
+
+    print(new_content, file=output_go, end='')
+    output_go.flush()
+    os.remove(tmp.name)
+
+
+def _set_typedef_defaults(typedef):
+    typedef.setdefault('doctail', '')
+    typedef.setdefault('context_type', typedef['type'])
+    typedef.setdefault('dest', True)
+    typedef.setdefault('value', True)
+    typedef.setdefault('parser', 'f.Value, error(nil)')
+    typedef.setdefault('parser_cast', 'parsed')
+
+
+def _write_cli_flag_types(outfile, types):
+    _fwrite(outfile, """\
+        package cli
+
+        // WARNING: This file is generated!
+
+        """)
+
+    for typedef in types:
+        _set_typedef_defaults(typedef)
+
+        _fwrite(outfile, """\
+        // {name}Flag is a flag with type {type}{doctail}
+        type {name}Flag struct {{
+            Name string
+            Usage string
+            EnvVar string
+            Hidden bool
+        """.format(**typedef))
+
+        if typedef['value']:
+            _fwrite(outfile, """\
+            Value {type}
+            """.format(**typedef))
+
+        if typedef['dest']:
+            _fwrite(outfile, """\
+            Destination *{type}
+            """.format(**typedef))
+
+        _fwrite(outfile, "\n}\n\n")
+
+        _fwrite(outfile, """\
+            // String returns a readable representation of this value
+            // (for usage defaults)
+            func (f {name}Flag) String() string {{
+                return FlagStringer(f)
+            }}
+
+            // GetName returns the name of the flag
+            func (f {name}Flag) GetName() string {{
+                return f.Name
+            }}
+
+            // {name} looks up the value of a local {name}Flag, returns
+            // {context_default} if not found
+            func (c *Context) {name}(name string) {context_type} {{
+                return lookup{name}(name, c.flagSet)
+            }}
+
+            // Global{name} looks up the value of a global {name}Flag, returns
+            // {context_default} if not found
+            func (c *Context) Global{name}(name string) {context_type} {{
+                if fs := lookupGlobalFlagSet(name, c); fs != nil {{
+                    return lookup{name}(name, fs)
+                }}
+                return {context_default}
+            }}
+
+            func lookup{name}(name string, set *flag.FlagSet) {context_type} {{
+                f := set.Lookup(name)
+                if f != nil {{
+                    parsed, err := {parser}
+                    if err != nil {{
+                        return {context_default}
+                    }}
+                    return {parser_cast}
+                }}
+                return {context_default}
+            }}
+            """.format(**typedef))
+
+
+def _write_altsrc_flag_types(outfile, types):
+    _fwrite(outfile, """\
+        package altsrc
+
+        import (
+            "gopkg.in/urfave/cli.v1"
+        )
+
+        // WARNING: This file is generated!
+
+        """)
+
+    for typedef in types:
+        _set_typedef_defaults(typedef)
+
+        _fwrite(outfile, """\
+        // {name}Flag is the flag type that wraps cli.{name}Flag to allow
+        // for other values to be specified
+        type {name}Flag struct {{
+            cli.{name}Flag
+            set *flag.FlagSet
+        }}
+
+        // New{name}Flag creates a new {name}Flag
+        func New{name}Flag(fl cli.{name}Flag) *{name}Flag {{
+            return &{name}Flag{{{name}Flag: fl, set: nil}}
+        }}
+
+        // Apply saves the flagSet for later usage calls, then calls the
+        // wrapped {name}Flag.Apply
+        func (f *{name}Flag) Apply(set *flag.FlagSet) {{
+            f.set = set
+            f.{name}Flag.Apply(set)
+        }}
+
+        // ApplyWithError saves the flagSet for later usage calls, then calls the
+        // wrapped {name}Flag.ApplyWithError
+        func (f *{name}Flag) ApplyWithError(set *flag.FlagSet) error {{
+            f.set = set
+            return f.{name}Flag.ApplyWithError(set)
+        }}
+        """.format(**typedef))
+
+
+def _fwrite(outfile, text):
+    print(textwrap.dedent(text), end='', file=outfile)
+
+
+_WRITEFUNCS = {
+    'cli': _write_cli_flag_types,
+    'altsrc': _write_altsrc_flag_types
+}
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/vendor/github.com/urfave/cli/help.go
+++ b/vendor/github.com/urfave/cli/help.go
@@ -1,0 +1,294 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+)
+
+// AppHelpTemplate is the text template for the Default help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var AppHelpTemplate = `NAME:
+   {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+
+VERSION:
+   {{.Version}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}{{if len .Authors}}
+
+AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
+   {{range $index, $author := .Authors}}{{if $index}}
+   {{end}}{{$author}}{{end}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{range .VisibleCategories}}{{if .Name}}
+   {{.Name}}:{{end}}{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+
+GLOBAL OPTIONS:
+   {{range $index, $option := .VisibleFlags}}{{if $index}}
+   {{end}}{{$option}}{{end}}{{end}}{{if .Copyright}}
+
+COPYRIGHT:
+   {{.Copyright}}{{end}}
+`
+
+// CommandHelpTemplate is the text template for the command help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var CommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{if .Category}}
+
+CATEGORY:
+   {{.Category}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}{{if .VisibleFlags}}
+
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`
+
+// SubcommandHelpTemplate is the text template for the subcommand help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var SubcommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
+
+COMMANDS:{{range .VisibleCategories}}{{if .Name}}
+   {{.Name}}:{{end}}{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}
+{{end}}{{if .VisibleFlags}}
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`
+
+var helpCommand = Command{
+	Name:      "help",
+	Aliases:   []string{"h"},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
+	Action: func(c *Context) error {
+		args := c.Args()
+		if args.Present() {
+			return ShowCommandHelp(c, args.First())
+		}
+
+		ShowAppHelp(c)
+		return nil
+	},
+}
+
+var helpSubcommand = Command{
+	Name:      "help",
+	Aliases:   []string{"h"},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
+	Action: func(c *Context) error {
+		args := c.Args()
+		if args.Present() {
+			return ShowCommandHelp(c, args.First())
+		}
+
+		return ShowSubcommandHelp(c)
+	},
+}
+
+// Prints help for the App or Command
+type helpPrinter func(w io.Writer, templ string, data interface{})
+
+// HelpPrinter is a function that writes the help output. If not set a default
+// is used. The function signature is:
+// func(w io.Writer, templ string, data interface{})
+var HelpPrinter helpPrinter = printHelp
+
+// VersionPrinter prints the version for the App
+var VersionPrinter = printVersion
+
+// ShowAppHelp is an action that displays the help.
+func ShowAppHelp(c *Context) error {
+	HelpPrinter(c.App.Writer, AppHelpTemplate, c.App)
+	return nil
+}
+
+// DefaultAppComplete prints the list of subcommands as the default app completion method
+func DefaultAppComplete(c *Context) {
+	for _, command := range c.App.Commands {
+		if command.Hidden {
+			continue
+		}
+		for _, name := range command.Names() {
+			fmt.Fprintln(c.App.Writer, name)
+		}
+	}
+}
+
+// ShowCommandHelp prints help for the given command
+func ShowCommandHelp(ctx *Context, command string) error {
+	// show the subcommand help for a command with subcommands
+	if command == "" {
+		HelpPrinter(ctx.App.Writer, SubcommandHelpTemplate, ctx.App)
+		return nil
+	}
+
+	for _, c := range ctx.App.Commands {
+		if c.HasName(command) {
+			HelpPrinter(ctx.App.Writer, CommandHelpTemplate, c)
+			return nil
+		}
+	}
+
+	if ctx.App.CommandNotFound == nil {
+		return NewExitError(fmt.Sprintf("No help topic for '%v'", command), 3)
+	}
+
+	ctx.App.CommandNotFound(ctx, command)
+	return nil
+}
+
+// ShowSubcommandHelp prints help for the given subcommand
+func ShowSubcommandHelp(c *Context) error {
+	return ShowCommandHelp(c, c.Command.Name)
+}
+
+// ShowVersion prints the version number of the App
+func ShowVersion(c *Context) {
+	VersionPrinter(c)
+}
+
+func printVersion(c *Context) {
+	fmt.Fprintf(c.App.Writer, "%v version %v\n", c.App.Name, c.App.Version)
+}
+
+// ShowCompletions prints the lists of commands within a given context
+func ShowCompletions(c *Context) {
+	a := c.App
+	if a != nil && a.BashComplete != nil {
+		a.BashComplete(c)
+	}
+}
+
+// ShowCommandCompletions prints the custom completions for a given command
+func ShowCommandCompletions(ctx *Context, command string) {
+	c := ctx.App.Command(command)
+	if c != nil && c.BashComplete != nil {
+		c.BashComplete(ctx)
+	}
+}
+
+func printHelp(out io.Writer, templ string, data interface{}) {
+	funcMap := template.FuncMap{
+		"join": strings.Join,
+	}
+
+	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)
+	t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
+	err := t.Execute(w, data)
+	if err != nil {
+		// If the writer is closed, t.Execute will fail, and there's nothing
+		// we can do to recover.
+		if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
+			fmt.Fprintf(ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
+		}
+		return
+	}
+	w.Flush()
+}
+
+func checkVersion(c *Context) bool {
+	found := false
+	if VersionFlag.Name != "" {
+		eachName(VersionFlag.Name, func(name string) {
+			if c.GlobalBool(name) || c.Bool(name) {
+				found = true
+			}
+		})
+	}
+	return found
+}
+
+func checkHelp(c *Context) bool {
+	found := false
+	if HelpFlag.Name != "" {
+		eachName(HelpFlag.Name, func(name string) {
+			if c.GlobalBool(name) || c.Bool(name) {
+				found = true
+			}
+		})
+	}
+	return found
+}
+
+func checkCommandHelp(c *Context, name string) bool {
+	if c.Bool("h") || c.Bool("help") {
+		ShowCommandHelp(c, name)
+		return true
+	}
+
+	return false
+}
+
+func checkSubcommandHelp(c *Context) bool {
+	if c.Bool("h") || c.Bool("help") {
+		ShowSubcommandHelp(c)
+		return true
+	}
+
+	return false
+}
+
+func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
+	if !a.EnableBashCompletion {
+		return false, arguments
+	}
+
+	pos := len(arguments) - 1
+	lastArg := arguments[pos]
+
+	if lastArg != "--"+BashCompletionFlag.Name {
+		return false, arguments
+	}
+
+	return true, arguments[:pos]
+}
+
+func checkCompletions(c *Context) bool {
+	if !c.shellComplete {
+		return false
+	}
+
+	if args := c.Args(); args.Present() {
+		name := args.First()
+		if cmd := c.App.Command(name); cmd != nil {
+			// let the command handle the completion
+			return false
+		}
+	}
+
+	ShowCompletions(c)
+	return true
+}
+
+func checkCommandCompletions(c *Context, name string) bool {
+	if !c.shellComplete {
+		return false
+	}
+
+	ShowCommandCompletions(c, name)
+	return true
+}

--- a/vendor/github.com/urfave/cli/help_test.go
+++ b/vendor/github.com/urfave/cli/help_test.go
@@ -1,0 +1,289 @@
+package cli
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func Test_ShowAppHelp_NoAuthor(t *testing.T) {
+	output := new(bytes.Buffer)
+	app := NewApp()
+	app.Writer = output
+
+	c := NewContext(app, nil, nil)
+
+	ShowAppHelp(c)
+
+	if bytes.Index(output.Bytes(), []byte("AUTHOR(S):")) != -1 {
+		t.Errorf("expected\n%snot to include %s", output.String(), "AUTHOR(S):")
+	}
+}
+
+func Test_ShowAppHelp_NoVersion(t *testing.T) {
+	output := new(bytes.Buffer)
+	app := NewApp()
+	app.Writer = output
+
+	app.Version = ""
+
+	c := NewContext(app, nil, nil)
+
+	ShowAppHelp(c)
+
+	if bytes.Index(output.Bytes(), []byte("VERSION:")) != -1 {
+		t.Errorf("expected\n%snot to include %s", output.String(), "VERSION:")
+	}
+}
+
+func Test_ShowAppHelp_HideVersion(t *testing.T) {
+	output := new(bytes.Buffer)
+	app := NewApp()
+	app.Writer = output
+
+	app.HideVersion = true
+
+	c := NewContext(app, nil, nil)
+
+	ShowAppHelp(c)
+
+	if bytes.Index(output.Bytes(), []byte("VERSION:")) != -1 {
+		t.Errorf("expected\n%snot to include %s", output.String(), "VERSION:")
+	}
+}
+
+func Test_Help_Custom_Flags(t *testing.T) {
+	oldFlag := HelpFlag
+	defer func() {
+		HelpFlag = oldFlag
+	}()
+
+	HelpFlag = BoolFlag{
+		Name:  "help, x",
+		Usage: "show help",
+	}
+
+	app := App{
+		Flags: []Flag{
+			BoolFlag{Name: "foo, h"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Bool("h") != true {
+				t.Errorf("custom help flag not set")
+			}
+			return nil
+		},
+	}
+	output := new(bytes.Buffer)
+	app.Writer = output
+	app.Run([]string{"test", "-h"})
+	if output.Len() > 0 {
+		t.Errorf("unexpected output: %s", output.String())
+	}
+}
+
+func Test_Version_Custom_Flags(t *testing.T) {
+	oldFlag := VersionFlag
+	defer func() {
+		VersionFlag = oldFlag
+	}()
+
+	VersionFlag = BoolFlag{
+		Name:  "version, V",
+		Usage: "show version",
+	}
+
+	app := App{
+		Flags: []Flag{
+			BoolFlag{Name: "foo, v"},
+		},
+		Action: func(ctx *Context) error {
+			if ctx.Bool("v") != true {
+				t.Errorf("custom version flag not set")
+			}
+			return nil
+		},
+	}
+	output := new(bytes.Buffer)
+	app.Writer = output
+	app.Run([]string{"test", "-v"})
+	if output.Len() > 0 {
+		t.Errorf("unexpected output: %s", output.String())
+	}
+}
+
+func Test_helpCommand_Action_ErrorIfNoTopic(t *testing.T) {
+	app := NewApp()
+
+	set := flag.NewFlagSet("test", 0)
+	set.Parse([]string{"foo"})
+
+	c := NewContext(app, set, nil)
+
+	err := helpCommand.Action.(func(*Context) error)(c)
+
+	if err == nil {
+		t.Fatalf("expected error from helpCommand.Action(), but got nil")
+	}
+
+	exitErr, ok := err.(*ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError from helpCommand.Action(), but instead got: %v", err.Error())
+	}
+
+	if !strings.HasPrefix(exitErr.Error(), "No help topic for") {
+		t.Fatalf("expected an unknown help topic error, but got: %v", exitErr.Error())
+	}
+
+	if exitErr.exitCode != 3 {
+		t.Fatalf("expected exit value = 3, got %d instead", exitErr.exitCode)
+	}
+}
+
+func Test_helpCommand_InHelpOutput(t *testing.T) {
+	app := NewApp()
+	output := &bytes.Buffer{}
+	app.Writer = output
+	app.Run([]string{"test", "--help"})
+
+	s := output.String()
+
+	if strings.Contains(s, "\nCOMMANDS:\nGLOBAL OPTIONS:\n") {
+		t.Fatalf("empty COMMANDS section detected: %q", s)
+	}
+
+	if !strings.Contains(s, "help, h") {
+		t.Fatalf("missing \"help, h\": %q", s)
+	}
+}
+
+func Test_helpSubcommand_Action_ErrorIfNoTopic(t *testing.T) {
+	app := NewApp()
+
+	set := flag.NewFlagSet("test", 0)
+	set.Parse([]string{"foo"})
+
+	c := NewContext(app, set, nil)
+
+	err := helpSubcommand.Action.(func(*Context) error)(c)
+
+	if err == nil {
+		t.Fatalf("expected error from helpCommand.Action(), but got nil")
+	}
+
+	exitErr, ok := err.(*ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError from helpCommand.Action(), but instead got: %v", err.Error())
+	}
+
+	if !strings.HasPrefix(exitErr.Error(), "No help topic for") {
+		t.Fatalf("expected an unknown help topic error, but got: %v", exitErr.Error())
+	}
+
+	if exitErr.exitCode != 3 {
+		t.Fatalf("expected exit value = 3, got %d instead", exitErr.exitCode)
+	}
+}
+
+func TestShowAppHelp_CommandAliases(t *testing.T) {
+	app := &App{
+		Commands: []Command{
+			{
+				Name:    "frobbly",
+				Aliases: []string{"fr", "frob"},
+				Action: func(ctx *Context) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	app.Writer = output
+	app.Run([]string{"foo", "--help"})
+
+	if !strings.Contains(output.String(), "frobbly, fr, frob") {
+		t.Errorf("expected output to include all command aliases; got: %q", output.String())
+	}
+}
+
+func TestShowCommandHelp_CommandAliases(t *testing.T) {
+	app := &App{
+		Commands: []Command{
+			{
+				Name:    "frobbly",
+				Aliases: []string{"fr", "frob", "bork"},
+				Action: func(ctx *Context) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	app.Writer = output
+	app.Run([]string{"foo", "help", "fr"})
+
+	if !strings.Contains(output.String(), "frobbly") {
+		t.Errorf("expected output to include command name; got: %q", output.String())
+	}
+
+	if strings.Contains(output.String(), "bork") {
+		t.Errorf("expected output to exclude command aliases; got: %q", output.String())
+	}
+}
+
+func TestShowSubcommandHelp_CommandAliases(t *testing.T) {
+	app := &App{
+		Commands: []Command{
+			{
+				Name:    "frobbly",
+				Aliases: []string{"fr", "frob", "bork"},
+				Action: func(ctx *Context) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	app.Writer = output
+	app.Run([]string{"foo", "help"})
+
+	if !strings.Contains(output.String(), "frobbly, fr, frob, bork") {
+		t.Errorf("expected output to include all command aliases; got: %q", output.String())
+	}
+}
+
+func TestShowAppHelp_HiddenCommand(t *testing.T) {
+	app := &App{
+		Commands: []Command{
+			{
+				Name: "frobbly",
+				Action: func(ctx *Context) error {
+					return nil
+				},
+			},
+			{
+				Name:   "secretfrob",
+				Hidden: true,
+				Action: func(ctx *Context) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	app.Writer = output
+	app.Run([]string{"app", "--help"})
+
+	if strings.Contains(output.String(), "secretfrob") {
+		t.Errorf("expected output to exclude \"secretfrob\"; got: %q", output.String())
+	}
+
+	if !strings.Contains(output.String(), "frobbly") {
+		t.Errorf("expected output to include \"frobbly\"; got: %q", output.String())
+	}
+}

--- a/vendor/github.com/urfave/cli/helpers_test.go
+++ b/vendor/github.com/urfave/cli/helpers_test.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var (
+	wd, _ = os.Getwd()
+)
+
+func expect(t *testing.T, a interface{}, b interface{}) {
+	_, fn, line, _ := runtime.Caller(1)
+	fn = strings.Replace(fn, wd+"/", "", -1)
+
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("(%s:%d) Expected %v (type %v) - Got %v (type %v)", fn, line, b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	}
+}
+
+func refute(t *testing.T, a interface{}, b interface{}) {
+	if reflect.DeepEqual(a, b) {
+		t.Errorf("Did not expect %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	}
+}

--- a/vendor/github.com/urfave/cli/helpers_unix_test.go
+++ b/vendor/github.com/urfave/cli/helpers_unix_test.go
@@ -1,0 +1,9 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package cli
+
+import "os"
+
+func clearenv() {
+	os.Clearenv()
+}

--- a/vendor/github.com/urfave/cli/helpers_windows_test.go
+++ b/vendor/github.com/urfave/cli/helpers_windows_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+// os.Clearenv() doesn't actually unset variables on Windows
+// See: https://github.com/golang/go/issues/17902
+func clearenv() {
+	for _, s := range os.Environ() {
+		for j := 1; j < len(s); j++ {
+			if s[j] == '=' {
+				keyp, _ := syscall.UTF16PtrFromString(s[0:j])
+				syscall.SetEnvironmentVariable(keyp, nil)
+				break
+			}
+		}
+	}
+}

--- a/vendor/github.com/urfave/cli/runtests
+++ b/vendor/github.com/urfave/cli/runtests
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+import tempfile
+
+from subprocess import check_call, check_output
+
+
+PACKAGE_NAME = os.environ.get(
+    'CLI_PACKAGE_NAME', 'github.com/urfave/cli'
+)
+
+
+def main(sysargs=sys.argv[:]):
+    targets = {
+        'vet': _vet,
+        'test': _test,
+        'gfmrun': _gfmrun,
+        'toc': _toc,
+        'gen': _gen,
+    }
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'target', nargs='?', choices=tuple(targets.keys()), default='test'
+    )
+    args = parser.parse_args(sysargs[1:])
+
+    targets[args.target]()
+    return 0
+
+
+def _test():
+    if check_output('go version'.split()).split()[2] < 'go1.2':
+        _run('go test -v .')
+        return
+
+    coverprofiles = []
+    for subpackage in ['', 'altsrc']:
+        coverprofile = 'cli.coverprofile'
+        if subpackage != '':
+            coverprofile = '{}.coverprofile'.format(subpackage)
+
+        coverprofiles.append(coverprofile)
+
+        _run('go test -v'.split() + [
+            '-coverprofile={}'.format(coverprofile),
+            ('{}/{}'.format(PACKAGE_NAME, subpackage)).rstrip('/')
+        ])
+
+    combined_name = _combine_coverprofiles(coverprofiles)
+    _run('go tool cover -func={}'.format(combined_name))
+    os.remove(combined_name)
+
+
+def _gfmrun():
+    go_version = check_output('go version'.split()).split()[2]
+    if go_version < 'go1.3':
+        print('runtests: skip on {}'.format(go_version), file=sys.stderr)
+        return
+    _run(['gfmrun', '-c', str(_gfmrun_count()), '-s', 'README.md'])
+
+
+def _vet():
+    _run('go vet ./...')
+
+
+def _toc():
+    _run('node_modules/.bin/markdown-toc -i README.md')
+    _run('git diff --exit-code')
+
+
+def _gen():
+    go_version = check_output('go version'.split()).split()[2]
+    if go_version < 'go1.5':
+        print('runtests: skip on {}'.format(go_version), file=sys.stderr)
+        return
+
+    _run('go generate ./...')
+    _run('git diff --exit-code')
+
+
+def _run(command):
+    if hasattr(command, 'split'):
+        command = command.split()
+    print('runtests: {}'.format(' '.join(command)), file=sys.stderr)
+    check_call(command)
+
+
+def _gfmrun_count():
+    with open('README.md') as infile:
+        lines = infile.read().splitlines()
+        return len(filter(_is_go_runnable, lines))
+
+
+def _is_go_runnable(line):
+    return line.startswith('package main')
+
+
+def _combine_coverprofiles(coverprofiles):
+    combined = tempfile.NamedTemporaryFile(
+        suffix='.coverprofile', delete=False
+    )
+    combined.write('mode: set\n')
+
+    for coverprofile in coverprofiles:
+        with open(coverprofile, 'r') as infile:
+            for line in infile.readlines():
+                if not line.startswith('mode: '):
+                    combined.write(line)
+
+    combined.flush()
+    name = combined.name
+    combined.close()
+    return name
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
- Add `urfave/cli` to `vendor/`
- Print the version information for `kubectl` and the cluster
- Fix some CLI helptext
- Remove `workspace`, `repo`, `build`, and `system` variables
- Add `log` function for formatting messages for the log output
- Add a step to validate the rendered `.kube.yml` manifest when attempting to apply it
- Allow the `project` value to be specified if the service account has the ability to fetch GKE credentials in multiple projects
  - This can simplify credential passing as the tradeoff of key isolation
  - Possible use case: clusters in sibling projects using a SA from a parent project
- Remove ability to specify a different `gcloud` or `kubectl`

Documentation updates in #40.