### PR TITLE
Remove latest tag when pushing a release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,7 +60,6 @@ pipeline:
     image: plugins/docker
     repo: nytimes/drone-gke
     tag:
-      - "latest"
       - "${DRONE_TAG}"
     secrets:
       - docker_username


### PR DESCRIPTION
Don't want to move `latest` if a maintenance version is tagged.