### PR TITLE
Wait until deploy completes

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -13,6 +13,8 @@ The following parameters are used to configure this plugin:
 * *optional* `namespace` - Kubernetes namespace to operate in (defaults to `default`)
 * *optional* `template` - Kubernetes manifest template (defaults to `.kube.yml`)
 * *optional* `secret_template` - Kubernetes [_Secret_ resource](http://kubernetes.io/docs/user-guide/secrets/) manifest template (defaults to `.kube.sec.yml`)
+* *optional* `wait_deployments` - list of deployments to check after apply
+* *optional* `wait_seconds` - if `wait_deployments` is set, maximum number of seconds for rollout (the exceeded timeout сauses the build to fail)
 * `vars` - variables to use in `template` and `secret_template`
 * `secrets` - credential and variables to use in `secret_template` (see [below](#secrets) for details)
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -13,8 +13,8 @@ The following parameters are used to configure this plugin:
 * *optional* `namespace` - Kubernetes namespace to operate in (defaults to `default`)
 * *optional* `template` - Kubernetes manifest template (defaults to `.kube.yml`)
 * *optional* `secret_template` - Kubernetes [_Secret_ resource](http://kubernetes.io/docs/user-guide/secrets/) manifest template (defaults to `.kube.sec.yml`)
-* *optional* `wait_deployments` - list of deployments to check after apply
-* *optional* `wait_seconds` - if `wait_deployments` is set, maximum number of seconds for rollout (the exceeded timeout сauses the build to fail)
+* *optional* `wait_deployments` - list of Deployments to wait for successful rollout, using `kubectl rollout status`
+* *optional* `wait_seconds` - if `wait_deployments` is set, number of seconds to wait before failing the build
 * `vars` - variables to use in `template` and `secret_template`
 * `secrets` - credential and variables to use in `secret_template` (see [below](#secrets) for details)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #FROM google/cloud-sdk:161.0.0-alpine
 
 # kubectl 1.7.0
-FROM google/cloud-sdk:163.0.0-alpine
+FROM google/cloud-sdk:181.0.0-alpine
 
 # Install kubectl
 RUN gcloud components install kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # kubectl 1.6.6
-FROM google/cloud-sdk:161.0.0-alpine
+#FROM google/cloud-sdk:161.0.0-alpine
 
 # kubectl 1.7.0
-#FROM google/cloud-sdk:163.0.0-alpine
+FROM google/cloud-sdk:163.0.0-alpine
 
 # Install kubectl
 RUN gcloud components install kubectl

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func wrapMain() error {
 		},
 		cli.IntFlag{
 			Name:   "wait_seconds",
-			Usage:  "If wait_deployments is set, maximum number of seconds for rollout (optional)",
+			Usage:  "If wait_deployments is set, maximum number of seconds for rollout (optional). The exceeded timeout сauses the build to fail.",
 			EnvVar: "PLUGIN_WAIT_SECONDS",
 			Value:  0,
 		},

--- a/main.go
+++ b/main.go
@@ -130,12 +130,12 @@ func wrapMain() error {
 		},
 		cli.StringSliceFlag{
 			Name:   "wait_deployments",
-			Usage:  "List of deployments to check after apply (optional)",
+			Usage:  "List of Deployments to wait for successful rollout, using kubectl rollout status",
 			EnvVar: "PLUGIN_WAIT_DEPLOYMENTS",
 		},
 		cli.IntFlag{
 			Name:   "wait_seconds",
-			Usage:  "If wait_deployments is set, maximum number of seconds for rollout (optional). The exceeded timeout сauses the build to fail.",
+			Usage:  "If wait_deployments is set, number of seconds to wait before failing the build",
 			EnvVar: "PLUGIN_WAIT_SECONDS",
 			Value:  0,
 		},
@@ -432,10 +432,10 @@ func run(c *cli.Context) error {
 
 	for counter, deployment := range waitDeployments {
 		if waitDeploymentsCount > 1 {
-			counterProgress = fmt.Sprintf("[%d/%d]", counter + 1, waitDeploymentsCount)
+			counterProgress = fmt.Sprintf(" %d/%d", counter + 1, waitDeploymentsCount)
 		}
 
-		log(fmt.Sprintf("%sWaiting till rollout completes for %s\n", counterProgress, deployment))
+		log(fmt.Sprintf("Waiting until rollout completes for %s%s\n", deployment, counterProgress))
 
 		command := []string{"rollout", "status", "deployment", deployment}
 

--- a/main.go
+++ b/main.go
@@ -423,12 +423,19 @@ func run(c *cli.Context) error {
 		return fmt.Errorf("Error: %s\n", err)
 	}
 
+	// Waiting for rollout to finish
+
 	waitDeployments := c.StringSlice("wait_deployments")
 	waitSeconds := c.Int("wait_seconds")
 	waitDeploymentsCount := len(waitDeployments)
+	counterProgress := ""
 
 	for counter, deployment := range waitDeployments {
-		log(fmt.Sprintf("[%d/%d] Waiting till rollout completes for %s\n", counter + 1, waitDeploymentsCount, deployment))
+		if waitDeploymentsCount > 1 {
+			counterProgress = fmt.Sprintf("[%d/%d]", counter + 1, waitDeploymentsCount)
+		}
+
+		log(fmt.Sprintf("%sWaiting till rollout completes for %s\n", counterProgress, deployment))
 
 		command := []string{"rollout", "status", "deployment", deployment}
 


### PR DESCRIPTION
Related to #26 

Example usage:
```
    rollout_check: [bodega-server, bodega-server-envoy]
    rollout_timeout: 300
```
Example output:
```
$ timeout -t 300 kubectl rollout status deploy bodega-server --namespace pubp-dev
Waiting for rollout to finish: 2 old replicas are pending termination...
Waiting for rollout to finish: 2 old replicas are pending termination...
Waiting for rollout to finish: 2 old replicas are pending termination...
Waiting for rollout to finish: 2 old replicas are pending termination...
deployment "bodega-server" successfully rolled out
```
There are no checks for deamonset or statefulset, but it would be easy to add this functionality.