### PR TITLE
Bump gcloud SDK / kubectl to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM google/cloud-sdk:latest
+FROM google/cloud-sdk:183.0.0-alpine
 
 # Install kubectl
-RUN apt-get install kubectl
+RUN gcloud components install kubectl -q
 
 # Add the Drone plugin
 ADD drone-gke /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN ./google-cloud-sdk/install.sh --quiet
 
 # Install kubectl
 RUN ./google-cloud-sdk/bin/gcloud components install kubectl
+RUN ./google-cloud-sdk/bin/gcloud components update --quiet
 
 ENV CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,10 @@
-FROM alpine:3.4
-
-RUN apk add --no-cache curl python
-
-ENV GOOGLE_CLOUD_SDK_VERSION=179.0.0
-
-# Install the gcloud SDK
-RUN curl -fsSLo google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86_64.tar.gz
-RUN tar -xzf google-cloud-sdk.tar.gz
-RUN rm google-cloud-sdk.tar.gz
-RUN ./google-cloud-sdk/install.sh --quiet
+FROM google/cloud-sdk:latest
 
 # Install kubectl
-RUN ./google-cloud-sdk/bin/gcloud components install kubectl
-RUN ./google-cloud-sdk/bin/gcloud components update --quiet
-
-ENV CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
-
-# Clean up
-RUN rm -rf ./google-cloud-sdk/.install
+RUN apt-get install kubectl
 
 # Add the Drone plugin
 ADD drone-gke /bin/
 
+ENV CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
 ENTRYPOINT ["/bin/drone-gke"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 RUN apk add --no-cache curl python
 
-ENV GOOGLE_CLOUD_SDK_VERSION=161.0.0
+ENV GOOGLE_CLOUD_SDK_VERSION=179.0.0
 
 # Install the gcloud SDK
 RUN curl -fsSLo google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86_64.tar.gz


### PR DESCRIPTION
This is to facilitate `apply` actions against `PodSpecs` that have `HostAlias` fields (new in 1.7).