### PR TITLE
Bump version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
   path: src/github.com/NYTimes/drone-gke
 
 build_config: &config
-  image: golang:1.8
+  image: golang:1.9
   environment:
     - CGO_ENABLED=0
   commands:
@@ -12,7 +12,7 @@ build_config: &config
 
 pipeline:
   test:
-    image: golang:1.8
+    image: golang:1.9
     environment:
       - CGO_ENABLED=0
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ pipeline:
     repo: nytimes/drone-gke
     tag:
       - "latest"
-      - "0.7"
+      - "0.8"
     secrets:
       - docker_username
       - docker_password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Please update to the newest GA release.
 
 ## 0.7.1
 
-**FEATURES & IMPROVEMENTS**
+### FEATURES & IMPROVEMENTS
 
 - `kubectl` is updated to 1.8.4.
 
@@ -13,7 +13,7 @@ Please update to the newest GA release.
 
 The plugin is updated to Drone 0.5+ style (environment variables).
 
-**BREAKING CHANGES**
+### BREAKING CHANGES
 
 - Consumes Drone 0.5+ style secrets, causing breaking changes with secrets and the GCP token across the board.
 Please read the documentation for reference usage.
@@ -25,7 +25,7 @@ To reference other environment variables, pass them via `vars`.
   - `DRONE_BRANCH`
   - `DRONE_TAG`
 
-**FEATURES & IMPROVEMENTS**
+### FEATURES & IMPROVEMENTS
 
 - `kubectl` is updated to 1.6.6.
 - Secret templates now have access to non-secret `vars` for template rendering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Deprecated means no longer supported.
 Please update to the newest GA release.
 
+## 0.8.0
+
+### FEATURES & IMPROVEMENTS
+
+- Add functionality to wait for successful `Deployment` rollout using `kubectl rollout status`.
+
 ## 0.7.1
 
 ### FEATURES & IMPROVEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Please update to the newest GA release.
 
 ## 0.7.1
 
+**FEATURES & IMPROVEMENTS**
+
 - `kubectl` is updated to 1.8.4.
 
 ## 0.7.0


### PR DESCRIPTION
- Update changelog
- Bump version due to new features introduced in https://github.com/NYTimes/drone-gke/pull/58
- Use go 1.9