### PR TITLE
Reduce kubectl error output of secret file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,14 @@ RUN apk add --no-cache curl python
 ENV GOOGLE_CLOUD_SDK_VERSION=161.0.0
 
 # Install the gcloud SDK
-RUN curl -fsSLo google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86_64.tar.gz
-RUN tar -xzf google-cloud-sdk.tar.gz
-RUN rm google-cloud-sdk.tar.gz
-RUN ./google-cloud-sdk/install.sh --quiet
-
-# Install kubectl
-RUN ./google-cloud-sdk/bin/gcloud components install kubectl
+RUN curl -fsSLo google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86_64.tar.gz && \
+    tar -xzf google-cloud-sdk.tar.gz && \
+    rm google-cloud-sdk.tar.gz && \
+    ./google-cloud-sdk/install.sh --quiet && \
+    ./google-cloud-sdk/bin/gcloud components install kubectl && \
+    rm -rf ./google-cloud-sdk/.install
 
 ENV CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
-
-# Clean up
-RUN rm -rf ./google-cloud-sdk/.install
 
 # Add the Drone plugin
 ADD drone-gke /bin/

--- a/main.go
+++ b/main.go
@@ -319,7 +319,7 @@ func wrapMain() error {
 		if err != nil {
 			// Print the last line of stderr
 			var lastLine string
-			scanner := bufio.NewScanner(strings.NewReader(string(secStderr.Bytes())))
+			scanner := bufio.NewScanner(&secStderr)
 			for scanner.Scan() {
 				lastLine = scanner.Text()
 			}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -133,9 +135,9 @@ func wrapMain() error {
 		}
 	}()
 
-	e := os.Environ()
-	e = append(e, fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", keyPath))
-	runner := NewEnviron(workspace.Path, e, os.Stdout, os.Stderr)
+	environ := os.Environ()
+	environ = append(environ, fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", keyPath))
+	runner := NewEnviron(workspace.Path, environ, os.Stdout, os.Stderr)
 
 	err = runner.Run(vargs.GCloudCmd, "auth", "activate-service-account", "--key-file", keyPath)
 	if err != nil {
@@ -210,7 +212,10 @@ func wrapMain() error {
 	}
 
 	outPaths := make(map[string]string)
+
+	// YAML files path for kubectl
 	pathArg := []string{}
+	pathArgSecret := []string{}
 
 	for t, content := range mapping {
 		if t == "" {
@@ -255,7 +260,11 @@ func wrapMain() error {
 
 		f.Close()
 
-		pathArg = append(pathArg, outPaths[t])
+		if t == vargs.Template {
+			pathArg = append(pathArg, outPaths[t])
+		} else {
+			pathArgSecret = append(pathArgSecret, outPaths[t])
+		}
 	}
 
 	if vargs.Verbose {
@@ -299,6 +308,24 @@ func wrapMain() error {
 	err = runner.Run(vargs.KubectlCmd, "apply", "--filename", strings.Join(pathArg, ","))
 	if err != nil {
 		return fmt.Errorf("Error: %s\n", err)
+	}
+
+	// Apply Kubernetes secrets files.
+	// Separate runner for catching secret output
+	if len(pathArgSecret) > 0 {
+		var secStderr bytes.Buffer
+		runnerSecret := NewEnviron(workspace.Path, environ, os.Stdout, &secStderr)
+		err = runnerSecret.Run(vargs.KubectlCmd, "apply", "--filename", strings.Join(pathArgSecret, ","))
+		if err != nil {
+			// Print the last line of stderr
+			var lastLine string
+			scanner := bufio.NewScanner(strings.NewReader(string(secStderr.Bytes())))
+			for scanner.Scan() {
+				lastLine = scanner.Text()
+			}
+			fmt.Fprintf(os.Stderr, "%s\n", lastLine)
+			return fmt.Errorf("Error: %s\n", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Same fix as #61, but added check on optional template `.kube.sec.yml`.