### PR TITLE
Update SDK to 187.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 RUN apk add --no-cache curl python
 
-ENV GOOGLE_CLOUD_SDK_VERSION=161.0.0
+ENV GOOGLE_CLOUD_SDK_VERSION=187.0.0
 
 # Install the gcloud SDK
 RUN curl -fsSLo google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86_64.tar.gz && \


### PR DESCRIPTION
Closes #59.

The reason to not use `FROM google/cloud-sdk:alpine` is because in order to rebuild it, we need to bump the repo to rebuild the image. This may change if the repo can be linked to automated builds on Docker Hub.

# Post-merge

- [ ] Tag a `0.4.4` release.