### PR TITLE
Add initial tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ pipeline:
       - CGO_ENABLED=0
     commands:
       - go vet
-      - go test -cover -coverprofile=coverage.out
+      - go test -cover
 
   build:
     <<: *config

--- a/dump_test.go
+++ b/dump_test.go
@@ -1,9 +1,39 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestDumpData(t *testing.T) {
+	// String
+	output := &bytes.Buffer{}
+	dumpData(output, "TEST 1", "test_string")
+	assert.Equal(t, output.String(), "---START TEST 1---\n\"test_string\"\n---END TEST 1---\n")
+
+	// JSON encoding
+	output.Reset()
+	dumpData(output, "TEST 2", map[string]int{"one": 1})
+	assert.Equal(t, output.String(), "---START TEST 2---\n{\n\t\"one\": 1\n}\n---END TEST 2---\n")
 }
 
 func TestDumpFile(t *testing.T) {
+	// Write to a new file
+	const path = "/tmp/drone-gke-test-dump"
+	data := []byte("hello, gke")
+	err := ioutil.WriteFile(path, data, 0644)
+
+	if assert.NoError(t, err) {
+		output := &bytes.Buffer{}
+		dumpFile(output, "TEST FILE", path)
+		assert.Equal(t, output.String(), "---START TEST FILE---\nhello, gke\n---END TEST FILE---\n")
+	}
+
+	// Delete file
+	err = os.Remove(path)
+	assert.NoError(t, err)
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -13,12 +13,12 @@ func TestDumpData(t *testing.T) {
 	// String
 	output := &bytes.Buffer{}
 	dumpData(output, "TEST 1", "test_string")
-	assert.Equal(t, output.String(), "---START TEST 1---\n\"test_string\"\n---END TEST 1---\n")
+	assert.Equal(t, "\n---START TEST 1---\n\"test_string\"\n---END TEST 1---\n", output.String())
 
 	// JSON encoding
 	output.Reset()
 	dumpData(output, "TEST 2", map[string]int{"one": 1})
-	assert.Equal(t, output.String(), "---START TEST 2---\n{\n\t\"one\": 1\n}\n---END TEST 2---\n")
+	assert.Equal(t, "\n---START TEST 2---\n{\n\t\"one\": 1\n}\n---END TEST 2---\n", output.String())
 }
 
 func TestDumpFile(t *testing.T) {
@@ -30,7 +30,7 @@ func TestDumpFile(t *testing.T) {
 	if assert.NoError(t, err) {
 		output := &bytes.Buffer{}
 		dumpFile(output, "TEST FILE", path)
-		assert.Equal(t, output.String(), "---START TEST FILE---\nhello, gke\n---END TEST FILE---\n")
+		assert.Equal(t, "\n---START TEST FILE---\nhello, gke\n---END TEST FILE---\n", output.String())
 	}
 
 	// Delete file

--- a/exec.go
+++ b/exec.go
@@ -7,15 +7,20 @@ import (
 	"strings"
 )
 
-type Environ struct {
+type Runner interface {
+	Run(name string, arg ...string) error
+}
+
+type BasicRunner struct {
+	Runner
 	dir    string
 	env    []string
 	stdout io.Writer
 	stderr io.Writer
 }
 
-func NewEnviron(dir string, env []string, stdout, stderr io.Writer) *Environ {
-	return &Environ{
+func NewBasicRunner(dir string, env []string, stdout, stderr io.Writer) *BasicRunner {
+	return &BasicRunner{
 		dir:    dir,
 		env:    env,
 		stdout: stdout,
@@ -24,7 +29,7 @@ func NewEnviron(dir string, env []string, stdout, stderr io.Writer) *Environ {
 }
 
 // Run executes the given program.
-func (e *Environ) Run(name string, arg ...string) error {
+func (e *BasicRunner) Run(name string, arg ...string) error {
 	cmd := exec.Command(name, arg...)
 	cmd.Dir = e.dir
 	cmd.Env = e.env

--- a/exec_test.go
+++ b/exec_test.go
@@ -11,7 +11,7 @@ func TestEnvironRun(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	e := &Environ{
+	e := &BasicRunner{
 		dir:    "/tmp",
 		env:    []string{"A=1"},
 		stdout: stdout,

--- a/main.go
+++ b/main.go
@@ -227,11 +227,12 @@ func run(c *cli.Context) error {
 		dumpFile(os.Stdout, "RENDERED MANIFEST (Secret Manifest Omitted)", manifestPaths[c.String("kube-template")])
 	}
 
-	// Print kubectl version
+	// kubectl version
 	if err := printKubectlVersion(runner); err != nil {
 		return fmt.Errorf("Error: %s\n", err)
 	}
 
+	// Set namespace and ensure it exists
 	if err := setNamespace(c, project, runner); err != nil {
 		return fmt.Errorf("Error: %s\n", err)
 	}

--- a/main.go
+++ b/main.go
@@ -247,7 +247,7 @@ func run(c *cli.Context) error {
 	}
 
 	// Waiting for rollout to finish
-	if err := waitForRollout(c, runner); err != nil {
+	if err := waitForRollout(c, runner, nil); err != nil {
 		return fmt.Errorf("Error: %s\n", err)
 	}
 
@@ -543,9 +543,17 @@ func applyManifests(c *cli.Context, manifestPaths map[string]string, runner Runn
 	return nil
 }
 
-func waitForRollout(c *cli.Context, runner Runner) error {
+// waitForRollout executes kubectl to wait for rollout to complete before continuing
+// The 3rd parameter waitDeployments is temporary and only used for testing, it
+// will be removed once better solution found
+func waitForRollout(c *cli.Context, runner Runner, waitDeployments []string) error {
+	// waitDeployments parameter overrides the one in cli.Context
+	// temporary for testing
+	if len(waitDeployments) == 0 {
+		waitDeployments = c.StringSlice("wait_deployments")
+	}
+
 	namespace := c.String("namespace")
-	waitDeployments := c.StringSlice("wait_deployments")
 	waitSeconds := c.Int("wait_seconds")
 	waitDeploymentsCount := len(waitDeployments)
 	counterProgress := ""

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
@@ -433,7 +434,9 @@ func renderTemplates(c *cli.Context, templateData map[string]interface{}, secret
 		}
 
 		// Create the output file.
-		manifestPaths[t] = path.Join(templateBasePath, t)
+		// If template is a path, extract file name
+		filename := filepath.Base(t)
+		manifestPaths[t] = path.Join(templateBasePath, filename)
 		f, err := os.Create(manifestPaths[t])
 		if err != nil {
 			return nil, fmt.Errorf("Error creating deployment file: %s\n", err)

--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func run(c *cli.Context) error {
 		return fmt.Errorf("Error: %s\n", err)
 	}
 
-	// Waiting for rollout to finish
+	// Wait for rollout to finish
 	if err := waitForRollout(c, runner, nil); err != nil {
 		return fmt.Errorf("Error: %s\n", err)
 	}
@@ -466,10 +466,12 @@ func renderTemplates(c *cli.Context, templateData map[string]interface{}, secret
 	return manifestPaths, nil
 }
 
+// printKubectlVersion runs kubectl version
 func printKubectlVersion(runner Runner) error {
 	return runner.Run(kubectlCmd, "version")
 }
 
+// setNamespace sets namespace of current kubectl context and ensure it exists
 func setNamespace(c *cli.Context, project string, runner Runner) error {
 	namespace := c.String("namespace")
 	if namespace == "" {
@@ -502,6 +504,7 @@ func setNamespace(c *cli.Context, project string, runner Runner) error {
 	return nil
 }
 
+// applyManifests applies manifests using kubectl apply
 func applyManifests(c *cli.Context, manifestPaths map[string]string, runner Runner, runnerSecret Runner) error {
 
 	manifests := manifestPaths[c.String("kube-template")]
@@ -586,6 +589,7 @@ func waitForRollout(c *cli.Context, runner Runner, waitDeployments []string) err
 	return nil
 }
 
+// applyArgs creates args slice for kubectl apply command
 func applyArgs(dryrun bool, file string) []string {
 	args := []string{
 		"apply",

--- a/main_test.go
+++ b/main_test.go
@@ -3,14 +3,26 @@ package main
 import (
 	"bytes"
 	"flag"
-	// "io/ioutil"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/urfave/cli"
 )
+
+type MockedRunner struct {
+	mock.Mock
+	Runner
+}
+
+func (m *MockedRunner) Run(name string, arg ...string) error {
+	args := m.Called(append([]string{name}, arg...))
+	return args.Error(0)
+}
 
 func TestCheckParams(t *testing.T) {
 	// Testing with cli.Context:
@@ -25,8 +37,14 @@ func TestCheckParams(t *testing.T) {
 	// Required args set
 	set.String("token", "{}", "")
 	set.String("zone", "us-east1", "")
+	set.String("cluster", "cluster-0", "")
 	err = checkParams(c)
 	assert.NoError(t, err)
+}
+
+func TestGetProjectFromToken(t *testing.T) {
+	token := "{\"project_id\":\"nyt-test-proj\"}"
+	assert.Equal(t, "nyt-test-proj", getProjectFromToken(token))
 }
 
 func TestParseVars(t *testing.T) {
@@ -87,9 +105,56 @@ func TestParseSecrets(t *testing.T) {
 	// Not able to use os.Setenv() to set env vars without "=", or duplicate keys
 }
 
-func TestGetProjectFromToken(t *testing.T) {
-	token := "{\"project_id\":\"nyt-test-proj\"}"
-	assert.Equal(t, "nyt-test-proj", getProjectFromToken(token))
+func TestFetchCredentials(t *testing.T) {
+	// Set cli.Context
+	set := flag.NewFlagSet("test-set", 0)
+	set.String("token", "{\"key\", \"val\"}", "")
+	set.String("cluster", "cluster-0", "")
+	set.String("zone", "us-east1", "")
+	c := cli.NewContext(nil, set, nil)
+
+	// No error
+	testRunner := new(MockedRunner)
+	testRunner.On("Run", []string{"gcloud", "auth", "activate-service-account", "--key-file", "/tmp/gcloud.json"}).Return(nil)
+	testRunner.On("Run", []string{"gcloud", "container", "clusters", "get-credentials", "cluster-0", "--project", "nyt-test-proj", "--zone", "us-east1"}).Return(nil)
+	err := fetchCredentials(c, "nyt-test-proj", testRunner)
+	assert.NoError(t, err)
+	testRunner.AssertExpectations(t)
+
+	// Validate token file
+	buf, err := ioutil.ReadFile("/tmp/gcloud.json")
+	assert.Equal(t, "{\"key\", \"val\"}", string(buf))
+
+	// Run() error
+	testRunner = new(MockedRunner)
+	testRunner.On("Run", []string{"gcloud", "auth", "activate-service-account", "--key-file", "/tmp/gcloud.json"}).Return(fmt.Errorf("e"))
+	err = fetchCredentials(c, "nyt-test-proj", testRunner)
+	assert.Error(t, err)
+	testRunner.AssertExpectations(t)
+}
+
+func TestTemplateData(t *testing.T) {
+
+}
+
+func TestRenderTemplates(t *testing.T) {
+
+}
+
+func TestPrintKubectlVersion(t *testing.T) {
+
+}
+
+func TestSetNamespace(t *testing.T) {
+
+}
+
+func TestApplyManifests(t *testing.T) {
+
+}
+
+func TestWaitForRollout(t *testing.T) {
+
 }
 
 func TestApplyArgs(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,50 +1,81 @@
 package main
 
 import (
-    "bytes"
-    // "io/ioutil"
-    // "os"
-    "testing"
-    "strings"
+	"bytes"
+	"flag"
+	// "io/ioutil"
+	// "os"
+	"strings"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
-    "github.com/urfave/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
 )
 
 func TestCheckParams(t *testing.T) {
-    app := cli.NewApp()
-    // c := NewContext(app,nil, nil)
-    config, err := getConfig(c)
-    assert.NoError(t, err)
+	// Testing with cli.Context:
+	// https://github.com/urfave/cli/blob/master/context_test.go#L10
+
+	set := flag.NewFlagSet("test-set", 0)
+	c := cli.NewContext(nil, set, nil)
+	err := checkParams(c)
+	assert.Error(t, err)
+
+	// Complete
+	set.String("token", "{}", "")
+	set.String("zone", "us-east1", "")
+	err = checkParams(c)
+	assert.NoError(t, err)
+}
+
+func TestParseVars(t *testing.T) {
+	set := flag.NewFlagSet("test-set", 0)
+	c := cli.NewContext(nil, set, nil)
+	vars, err := parseVars(c)
+	assert.Equal(t, map[string]interface{}{}, vars)
+	assert.NoError(t, err)
+
+	// Invalid JSON
+	set.String("vars", "{", "")
+	vars, err = parseVars(c)
+	assert.Equal(t, map[string]interface{}(nil), vars)
+	assert.Error(t, err)
+
+	set = flag.NewFlagSet("test-set", 0)
+	set.String("vars", "{\"var0\": \"val0\", \"var1\": \"val1\"}", "")
+	c = cli.NewContext(nil, set, nil)
+	vars, err = parseVars(c)
+	assert.Equal(t, map[string]interface{}{"var0": "val0", "var1": "val1"}, vars)
+	assert.NoError(t, err)
 }
 
 func TestGetProjectFromToken(t *testing.T) {
-    token := "{\"project_id\":\"nyt-test-proj\"}"
-    assert.Equal(t, "nyt-test-proj", getProjectFromToken(token))
+	token := "{\"project_id\":\"nyt-test-proj\"}"
+	assert.Equal(t, "nyt-test-proj", getProjectFromToken(token))
 }
 
 func TestApplyArgs(t *testing.T) {
-    args := applyArgs(false, "/path/to/file/1")
-    assert.Equal(t, []string{"apply", "--record", "--filename", "/path/to/file/1"}, args)
+	args := applyArgs(false, "/path/to/file/1")
+	assert.Equal(t, []string{"apply", "--record", "--filename", "/path/to/file/1"}, args)
 
-    args = applyArgs(true, "/path/to/file/2")
-    assert.Equal(t, []string{"apply", "--record", "--dry-run", "--filename", "/path/to/file/2"}, args)
+	args = applyArgs(true, "/path/to/file/2")
+	assert.Equal(t, []string{"apply", "--record", "--dry-run", "--filename", "/path/to/file/2"}, args)
 }
 
 func TestPrintTrimmedError(t *testing.T) {
-    output := &bytes.Buffer{}
+	output := &bytes.Buffer{}
 
-    // Empty
-    printTrimmedError(strings.NewReader(""), output)
-    assert.Equal(t, "\n", output.String())
+	// Empty
+	printTrimmedError(strings.NewReader(""), output)
+	assert.Equal(t, "\n", output.String())
 
-    // One line
-    output.Reset()
-    printTrimmedError(strings.NewReader("one line"), output)
-    assert.Equal(t, "one line\n", output.String())
+	// One line
+	output.Reset()
+	printTrimmedError(strings.NewReader("one line"), output)
+	assert.Equal(t, "one line\n", output.String())
 
-    // Mutiple lines
-    output.Reset()
-    printTrimmedError(strings.NewReader("line 1\nline 2\nline 3"), output)
-    assert.Equal(t, "line 3\n", output.String())
+	// Mutiple lines
+	output.Reset()
+	printTrimmedError(strings.NewReader("line 1\nline 2\nline 3"), output)
+	assert.Equal(t, "line 3\n", output.String())
 }

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,10 @@ type MockedRunner struct {
 }
 
 func (m *MockedRunner) Run(name string, arg ...string) error {
+	// https://godoc.org/github.com/stretchr/testify/mock
+	// Arguments given in .On()
 	args := m.Called(append([]string{name}, arg...))
+	// Returns error given in .Return()
 	return args.Error(0)
 }
 
@@ -43,8 +46,8 @@ func TestCheckParams(t *testing.T) {
 }
 
 func TestGetProjectFromToken(t *testing.T) {
-	token := "{\"project_id\":\"nyt-test-proj\"}"
-	assert.Equal(t, "nyt-test-proj", getProjectFromToken(token))
+	token := "{\"project_id\":\"test-project\"}"
+	assert.Equal(t, "test-project", getProjectFromToken(token))
 }
 
 func TestParseVars(t *testing.T) {
@@ -61,7 +64,7 @@ func TestParseVars(t *testing.T) {
 	assert.Equal(t, map[string]interface{}(nil), vars)
 	assert.Error(t, err)
 
-	// Valid
+	// No error
 	set = flag.NewFlagSet("test-set", 0)
 	set.String("vars", "{\"var0\": \"val0\", \"var1\": \"val1\"}", "")
 	c = cli.NewContext(nil, set, nil)
@@ -79,7 +82,7 @@ func TestParseSecrets(t *testing.T) {
 	assert.Equal(t, map[string]string{}, secrets)
 	assert.NoError(t, err)
 
-	// Normal
+	// No error
 	os.Setenv("SECRET_TEST0", "test0")
 	os.Setenv("SECRET_TEST1", "test1")
 	os.Setenv("SECRET_BASE64_TEST0", "dGVzdDA=")
@@ -116,41 +119,218 @@ func TestFetchCredentials(t *testing.T) {
 	// No error
 	testRunner := new(MockedRunner)
 	testRunner.On("Run", []string{"gcloud", "auth", "activate-service-account", "--key-file", "/tmp/gcloud.json"}).Return(nil)
-	testRunner.On("Run", []string{"gcloud", "container", "clusters", "get-credentials", "cluster-0", "--project", "nyt-test-proj", "--zone", "us-east1"}).Return(nil)
-	err := fetchCredentials(c, "nyt-test-proj", testRunner)
-	assert.NoError(t, err)
+	testRunner.On("Run", []string{"gcloud", "container", "clusters", "get-credentials", "cluster-0", "--project", "test-project", "--zone", "us-east1"}).Return(nil)
+	err := fetchCredentials(c, "test-project", testRunner)
 	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
 
-	// Validate token file
+	// Verify token file
 	buf, err := ioutil.ReadFile("/tmp/gcloud.json")
 	assert.Equal(t, "{\"key\", \"val\"}", string(buf))
 
 	// Run() error
 	testRunner = new(MockedRunner)
 	testRunner.On("Run", []string{"gcloud", "auth", "activate-service-account", "--key-file", "/tmp/gcloud.json"}).Return(fmt.Errorf("e"))
-	err = fetchCredentials(c, "nyt-test-proj", testRunner)
-	assert.Error(t, err)
+	err = fetchCredentials(c, "test-project", testRunner)
 	testRunner.AssertExpectations(t)
+	assert.Error(t, err)
 }
 
 func TestTemplateData(t *testing.T) {
+	// Set cli.Context with data
+	set := flag.NewFlagSet("test-set", 0)
+	set.String("drone-branch", "master", "")
+	set.String("drone-build-number", "2", "")
+	set.String("drone-commit", "e0f21b90a", "")
+	set.String("drone-tag", "v0.0.0", "")
+	set.String("cluster", "cluster-0", "")
+	set.String("zone", "us-east1", "")
+	c := cli.NewContext(nil, set, nil)
 
+	// No error
+	// Create data maps
+	vars := map[string]interface{}{"key0": "val0"}
+	secrets := map[string]string{"SECRET_TEST": "test_val"}
+
+	// Call
+	tmplData, secretsData, secretsDataRedacted, err := templateData(c, "test-project", vars, secrets)
+
+	// Verify
+	assert.Equal(t, map[string]interface{}{
+		"BRANCH":       "master",
+		"BUILD_NUMBER": "2",
+		"COMMIT":       "e0f21b90a",
+		"TAG":          "v0.0.0",
+		"project":      "test-project",
+		"zone":         "us-east1",
+		"cluster":      "cluster-0",
+		"namespace":    "",
+		"key0":         "val0",
+	}, tmplData)
+
+	assert.Equal(t, map[string]interface{}{"key0": "val0", "SECRET_TEST": "test_val"}, secretsData)
+	assert.Equal(t, map[string]string{"SECRET_TEST": "VALUE REDACTED"}, secretsDataRedacted)
+	assert.NoError(t, err)
+
+	// Variable overrides existing ones
+	vars = map[string]interface{}{"zone": "us-east4"}
+	tmplData, secretsData, secretsDataRedacted, err = templateData(c, "us-east1", vars, secrets)
+	assert.Error(t, err)
+
+	// Secret overrides variable
+	vars = map[string]interface{}{"SECRET_TEST": "val0"}
+	secrets = map[string]string{"SECRET_TEST": "test_val"}
+	tmplData, secretsData, secretsDataRedacted, err = templateData(c, "us-east1", vars, secrets)
+	assert.Error(t, err)
 }
 
 func TestRenderTemplates(t *testing.T) {
+	// Mkdir for testing template files
+	os.MkdirAll("/tmp/drone-gke-tests/", os.ModePerm)
+	kubeTemplatePath := "/tmp/drone-gke-tests/.kube.yml"
+	secretTemplatePath := "/tmp/drone-gke-tests/.kube.sec.yml"
 
+	// Set cli.Context with data
+	set := flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", kubeTemplatePath, "")
+	set.String("secret-template", secretTemplatePath, "")
+	c := cli.NewContext(nil, set, nil)
+
+	tmplData := map[string]interface{}{
+		"COMMIT": "e0f21b90a",
+		"key0":   "val0",
+	}
+	secretsData := map[string]interface{}{"SECRET_TEST": "test_sec_val"}
+
+	// No template file, should error
+	os.Remove(kubeTemplatePath)
+	os.Remove(secretTemplatePath)
+	_, err := renderTemplates(c, tmplData, secretsData)
+	assert.Error(t, err)
+
+	// Normal
+	// Create test template files
+	tmplBuf := []byte("{{.COMMIT}}-{{.key0}}")
+	err = ioutil.WriteFile(kubeTemplatePath, tmplBuf, 0600)
+	assert.NoError(t, err)
+	tmplBuf = []byte("{{.SECRET_TEST}}")
+	err = ioutil.WriteFile(secretTemplatePath, tmplBuf, 0600)
+	assert.NoError(t, err)
+
+	// Render
+	manifestPaths, err := renderTemplates(c, tmplData, secretsData)
+	assert.NoError(t, err)
+
+	// Verify token files
+	buf, err := ioutil.ReadFile(manifestPaths[kubeTemplatePath])
+	assert.Equal(t, "e0f21b90a-val0", string(buf))
+
+	buf, err = ioutil.ReadFile(manifestPaths[secretTemplatePath])
+	assert.Equal(t, "test_sec_val", string(buf))
+
+	// Secret variables shouldn't be available in kube template
+	tmplBuf = []byte("{{.SECRET_TEST}}")
+	err = ioutil.WriteFile(kubeTemplatePath, tmplBuf, 0600)
+	_, err = renderTemplates(c, tmplData, secretsData)
+	assert.Error(t, err)
 }
 
 func TestPrintKubectlVersion(t *testing.T) {
-
+	testRunner := new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "version"}).Return(nil)
+	err := printKubectlVersion(testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
 }
 
 func TestSetNamespace(t *testing.T) {
+	// No error
+	set := flag.NewFlagSet("test-set", 0)
+	set.String("zone", "us-east1", "")
+	set.String("cluster", "cluster-0", "")
+	set.String("namespace", "test-ns", "")
+	set.Bool("dry-run", false, "")
+	c := cli.NewContext(nil, set, nil)
 
+	testRunner := new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "config", "set-context", "gke_test-project_us-east1_cluster-0", "--namespace", "test-ns"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--filename", "/tmp/namespace.json"}).Return(nil)
+	err := setNamespace(c, "test-project", testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+
+	// Verify written file
+	buf, err := ioutil.ReadFile("/tmp/namespace.json")
+	assert.Equal(t, "\n---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: test-ns\n", string(buf))
+
+	// Dry-run
+	set = flag.NewFlagSet("test-set", 0)
+	set.String("zone", "us-east1", "")
+	set.String("cluster", "cluster-0", "")
+	set.String("namespace", "test-ns", "")
+	set.Bool("dry-run", true, "")
+	c = cli.NewContext(nil, set, nil)
+
+	testRunner = new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "config", "set-context", "gke_test-project_us-east1_cluster-0", "--namespace", "test-ns"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--dry-run", "--filename", "/tmp/namespace.json"}).Return(nil)
+	err = setNamespace(c, "test-project", testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
 }
 
 func TestApplyManifests(t *testing.T) {
+	// Normal
+	set := flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", ".kube.yml", "")
+	set.String("secret-template", ".kube.sec.yml", "")
+	set.Bool("dry-run", false, "")
+	c := cli.NewContext(nil, set, nil)
 
+	manifestPaths := map[string]string{
+		".kube.yml":     "/path/to/kube-tamplate",
+		".kube.sec.yml": "/path/to/secret-tamplate",
+	}
+
+	testRunner := new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--dry-run", "--filename", "/path/to/kube-tamplate"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--dry-run", "--filename", "/path/to/secret-tamplate"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--filename", "/path/to/kube-tamplate"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--filename", "/path/to/secret-tamplate"}).Return(nil)
+	err := applyManifests(c, manifestPaths, testRunner, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+
+	// No secrets manifest
+	manifestPaths = map[string]string{
+		".kube.yml": "/path/to/kube-tamplate",
+	}
+
+	testRunner = new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--dry-run", "--filename", "/path/to/kube-tamplate"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--filename", "/path/to/kube-tamplate"}).Return(nil)
+	err = applyManifests(c, manifestPaths, testRunner, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+
+	// Dry-run
+	set = flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", ".kube.yml", "")
+	set.String("secret-template", ".kube.sec.yml", "")
+	set.Bool("dry-run", true, "")
+	c = cli.NewContext(nil, set, nil)
+
+	manifestPaths = map[string]string{
+		".kube.yml":     "/path/to/kube-tamplate",
+		".kube.sec.yml": "/path/to/secret-tamplate",
+	}
+
+	testRunner = new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--dry-run", "--filename", "/path/to/kube-tamplate"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--dry-run", "--filename", "/path/to/secret-tamplate"}).Return(nil)
+	err = applyManifests(c, manifestPaths, testRunner, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
 }
 
 func TestWaitForRollout(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+    "bytes"
+    // "io/ioutil"
+    // "os"
+    "testing"
+    "strings"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/urfave/cli"
+)
+
+func TestCheckParams(t *testing.T) {
+    app := cli.NewApp()
+    // c := NewContext(app,nil, nil)
+    config, err := getConfig(c)
+    assert.NoError(t, err)
+}
+
+func TestGetProjectFromToken(t *testing.T) {
+    token := "{\"project_id\":\"nyt-test-proj\"}"
+    assert.Equal(t, "nyt-test-proj", getProjectFromToken(token))
+}
+
+func TestApplyArgs(t *testing.T) {
+    args := applyArgs(false, "/path/to/file/1")
+    assert.Equal(t, []string{"apply", "--record", "--filename", "/path/to/file/1"}, args)
+
+    args = applyArgs(true, "/path/to/file/2")
+    assert.Equal(t, []string{"apply", "--record", "--dry-run", "--filename", "/path/to/file/2"}, args)
+}
+
+func TestPrintTrimmedError(t *testing.T) {
+    output := &bytes.Buffer{}
+
+    // Empty
+    printTrimmedError(strings.NewReader(""), output)
+    assert.Equal(t, "\n", output.String())
+
+    // One line
+    output.Reset()
+    printTrimmedError(strings.NewReader("one line"), output)
+    assert.Equal(t, "one line\n", output.String())
+
+    // Mutiple lines
+    output.Reset()
+    printTrimmedError(strings.NewReader("line 1\nline 2\nline 3"), output)
+    assert.Equal(t, "line 3\n", output.String())
+}

--- a/main_test.go
+++ b/main_test.go
@@ -334,16 +334,16 @@ func TestApplyManifests(t *testing.T) {
 }
 
 func TestWaitForRollout(t *testing.T) {
-	// // No error
+	// No error
 	set := flag.NewFlagSet("test-set", 0)
-	// set.Set("wait_deployments", "[]string{\"a\",\"b\"}")
-	// set.Int("wait_seconds", 256, "")
+	set.Int("wait_seconds", 256, "")
 	set.String("namespace", "test-ns", "")
 	c := cli.NewContext(nil, set, nil)
 
 	testRunner := new(MockedRunner)
-	// testRunner.On("Run", []string{"kubectl", "config", "set-context", "gke_test-project_us-east1_cluster-0", "--namespace", "test-ns"}).Return(nil)
-	err := waitForRollout(c, testRunner)
+	testRunner.On("Run", []string{"timeout", "-t", "256", "kubectl", "rollout", "status", "deployment", "d1", "--namespace", "test-ns"}).Return(nil)
+	testRunner.On("Run", []string{"timeout", "-t", "256", "kubectl", "rollout", "status", "deployment", "d2", "--namespace", "test-ns"}).Return(nil)
+	err := waitForRollout(c, testRunner, []string{"d1", "d2"})
 	testRunner.AssertExpectations(t)
 	assert.NoError(t, err)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -334,7 +334,18 @@ func TestApplyManifests(t *testing.T) {
 }
 
 func TestWaitForRollout(t *testing.T) {
+	// // No error
+	set := flag.NewFlagSet("test-set", 0)
+	// set.Set("wait_deployments", "[]string{\"a\",\"b\"}")
+	// set.Int("wait_seconds", 256, "")
+	set.String("namespace", "test-ns", "")
+	c := cli.NewContext(nil, set, nil)
 
+	testRunner := new(MockedRunner)
+	// testRunner.On("Run", []string{"kubectl", "config", "set-context", "gke_test-project_us-east1_cluster-0", "--namespace", "test-ns"}).Return(nil)
+	err := waitForRollout(c, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
 }
 
 func TestApplyArgs(t *testing.T) {


### PR DESCRIPTION
Add tests to cover more code. The diff is large (might need to click on "Load diff" on `main.go`), but there's little change in logic. `run()` is not tested and no e2e tests as well for now, we should iterate on this and add later.

Main changes:
- Broke down run() to more functions and test individually.
- Created `Runner` interface and renamed `Environ` to enable mocking command execution.
