### PR TITLE
Add option for expanding environment variables used on vars

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -17,6 +17,7 @@ The following parameters are used to configure this plugin:
 * *optional* `wait_seconds` - if `wait_deployments` is set, number of seconds to wait before failing the build
 * `vars` - variables to use in `template` and `secret_template`
 * `secrets` - credential and variables to use in `secret_template` (see [below](#secrets) for details)
+* *optional* `expand_env_vars` - flag to specify whether the plugin should expand environment variables on values declared in `vars`
 
 ### Debugging parameters
 
@@ -104,10 +105,12 @@ pipeline:
     zone: us-central1-a
     cluster: my-gke-cluster
     namespace: ${DRONE_BRANCH}
+    expand_env_vars: true
     vars:
       image: gcr.io/my-gke-project/my-app:${DRONE_COMMIT}
       app: my-app
       env: dev
+      user: $${USER}
     secrets:
       - source: GOOGLE_CREDENTIALS
         target: token
@@ -148,6 +151,8 @@ spec:
           env:
             - name: APP_NAME
               value: {{.app}}
+            - name: USER
+              value: {{.user}}
             - name: API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/main.go
+++ b/main.go
@@ -118,6 +118,11 @@ func wrapMain() error {
 			Usage:  "variables to use while templating manifests",
 			EnvVar: "PLUGIN_VARS",
 		},
+		cli.BoolFlag{
+			Name:   "expand-env-vars",
+			Usage:  "expand environment variables contents on vars",
+			EnvVar: "PLUGIN_EXPAND_ENV_VARS",
+		},
 		cli.StringFlag{
 			Name:   "drone-build-number",
 			Usage:  "Drone build number",
@@ -386,6 +391,12 @@ func templateData(c *cli.Context, project string, vars map[string]interface{}, s
 		// We do this to ensure that the built-in template vars (above) can be relied upon.
 		if _, ok := templateData[k]; ok {
 			return nil, nil, nil, fmt.Errorf("Error: var %q shadows existing var\n", k)
+		}
+
+		if c.Bool("expand-env-vars") {
+			if rawValue, ok := v.(string); ok {
+				v = os.ExpandEnv(rawValue)
+			}
 		}
 
 		templateData[k] = v


### PR DESCRIPTION
The idea is to be able to support a declaration like the one below on
.drone.yml:

```
vars:
  image: $${IMAGE}
```

Environment variables are going to be expanded only the user explicitly
ask for it, avoiding an accidental breaking change in case some users
rely on the current behavior.

Please let me know if I should wait for #74 and add tests to the changes.