### PR TITLE
Update token to google_credentials

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -7,7 +7,7 @@ Use this plugin to deploy Docker images to [Google Container Engine (GKE)][gke].
 The following parameters are used to configure this plugin:
 
 * `image` - this plugin's Docker image
-* *optional* `project` - project of the container cluster (defaults to inferring from the service account `token` credential)
+* *optional* `project` - project of the container cluster (defaults to inferring from the service account credential)
 * `zone` - zone of the container cluster
 * `cluster` - name of the container cluster
 * *optional* `namespace` - Kubernetes namespace to operate in (defaults to `default`)
@@ -30,13 +30,13 @@ These optional parameters are useful for debugging:
 
 `drone-gke` requires a Google service account and uses it's [JSON credential file][service-account] to authenticate.
 
-This must be passed to the plugin under the target `token`.
+This must be passed to the plugin under the target `google_credentials`.
 
-The plugin infers the GCP project from the JSON credentials (`token`) and retrieves the GKE cluster credentials.
+The plugin infers the GCP project from the JSON credentials and retrieves the GKE cluster credentials.
 
 [service-account]: https://cloud.google.com/storage/docs/authentication#service_accounts
 
-### Setting the JSON token
+### Setting the JSON credential
 
 Improved in Drone 0.5+, it is no longer necessary to align the JSON file.
 
@@ -155,7 +155,7 @@ pipeline:
       user: $${USER}
     secrets:
       - source: GOOGLE_CREDENTIALS
-        target: token
+        target: google_credentials
       - source: API_TOKEN
         target: secret_api_token
       - source: P12_CERT

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ docker run --rm \
   -e PLUGIN_ZONE="$ZONE" \
   -e PLUGIN_NAMESPACE=drone-gke \
   -e PLUGIN_VARS="$(cat vars.json)" \
-  -e TOKEN="$(cat $GOOGLE_APPLICATION_CREDENTIALS)" \
+  -e GOOGLE_CREDENTIALS="$(cat $GOOGLE_APPLICATION_CREDENTIALS)" \
   -e SECRET_API_TOKEN=123 \
   -e SECRET_BASE64_P12_CERT="cDEyCg==" \
   -v $(pwd):$(pwd) \

--- a/main.go
+++ b/main.go
@@ -205,7 +205,7 @@ func run(c *cli.Context) error {
 	defer func() {
 		err := os.Remove(keyPath)
 		if err != nil {
-			log("Warning: error removing token file: %s\n", err)
+			log("Warning: error removing credentials file: %s\n", err)
 		}
 	}()
 
@@ -349,7 +349,7 @@ func fetchCredentials(c *cli.Context, project string, runner Runner) error {
 	// This is inside the ephemeral plugin container, not on the host.
 	err := ioutil.WriteFile(keyPath, []byte(c.String("token")), 0600)
 	if err != nil {
-		return fmt.Errorf("Error writing token file: %s\n", err)
+		return fmt.Errorf("Error writing credentials file: %s\n", err)
 	}
 
 	err = runner.Run(gcloudCmd, "auth", "activate-service-account", "--key-file", keyPath)

--- a/main.go
+++ b/main.go
@@ -78,12 +78,12 @@ func wrapMain() error {
 		},
 		cli.StringFlag{
 			Name:   "token",
-			Usage:  "service account's JSON credentials",
-			EnvVar: "TOKEN",
+			Usage:  "GCP service account JSON credentials",
+			EnvVar: "GOOGLE_CREDENTIALS,TOKEN",
 		},
 		cli.StringFlag{
 			Name:   "project",
-			Usage:  "GCP project name",
+			Usage:  "GCP project name, if not inferred from credentials",
 			EnvVar: "PLUGIN_PROJECT",
 		},
 		cli.StringFlag{
@@ -263,7 +263,7 @@ func run(c *cli.Context) error {
 // checkParams checks required params
 func checkParams(c *cli.Context) error {
 	if c.String("token") == "" {
-		return fmt.Errorf("Missing required param: token")
+		return fmt.Errorf("Missing required param: google_credentials")
 	}
 
 	if c.String("zone") == "" {


### PR DESCRIPTION
Bring into alignment with:
- https://github.com/drone-plugins/drone-google-cloudstorage/pull/12/files#diff-7ddfb3e035b42cd70649cc33393fe32cR49
- https://github.com/drone-plugins/drone-docker/blob/master/cmd/drone-docker-gcr/main.go#L21

Backwards compatible but will deprecate `token` (add release notes).