### PR TITLE
Hide all output from secrets apply step

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,8 +254,9 @@ func run(c *cli.Context) error {
 	runnerSecret := NewBasicRunner("", environ, os.Stdout, &secretStderr)
 	if err := applyManifests(c, manifestPaths, runner, runnerSecret); err != nil {
 		// Print last line of error of applying secret manifest to stderr
-		printTrimmedError(&secretStderr, os.Stderr)
-		return fmt.Errorf("Error: %s\n", err)
+		// Disable it for now as it might still leak secrets
+		// printTrimmedError(&secretStderr, os.Stderr)
+		return fmt.Errorf("Error (output redacted): %s\n", err)
 	}
 
 	// Wait for rollout to finish

--- a/main.go
+++ b/main.go
@@ -256,7 +256,7 @@ func run(c *cli.Context) error {
 		// Print last line of error of applying secret manifest to stderr
 		// Disable it for now as it might still leak secrets
 		// printTrimmedError(&secretStderr, os.Stderr)
-		return fmt.Errorf("Error (output redacted): %s\n", err)
+		return fmt.Errorf("Error (kubectl output redacted): %s\n", err)
 	}
 
 	// Wait for rollout to finish


### PR DESCRIPTION
Hide all output if there's error in `kubectl apply` step for secrets manifests, since trimming the output to last line may still leak secrets in some cases. This disables it for now until we have a better way to hide secrets and provide some info for debugging at the same time.

Test build: https://drone.dv.nyt.net/nytm/dv-yunzhu-sandbox/150/3