### PR TITLE
Support multiple kubectl versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,16 +3,23 @@ workspace:
   base: /go
   path: src/github.com/NYTimes/drone-gke
 
-build_config: &config
-  image: golang:1.9
+build_config: &build_config
+  image: golang:1.10
   environment:
     - CGO_ENABLED=0
   commands:
     - go build -a -ldflags "-X main.version=${DRONE_TAG:-0.8} -X main.rev=${DRONE_COMMIT}"
 
+publish_config: &publish_config
+  image: plugins/docker
+  repo: nytimes/drone-gke
+  secrets:
+    - docker_username
+    - docker_password
+
 pipeline:
   test:
-    image: golang:1.9
+    image: golang:1.10
     environment:
       - CGO_ENABLED=0
     commands:
@@ -20,52 +27,40 @@ pipeline:
       - go test -cover
 
   build:
-    <<: *config
+    <<: *build_config
     when:
       branch:
         - develop
         - master
 
   build_release:
-    <<: *config
+    <<: *build_config
     when:
       event: tag
 
   publish_develop:
-    image: plugins/docker
-    repo: nytimes/drone-gke
+    <<: *publish_config
     tag:
       - "develop"
-    secrets:
-      - docker_username
-      - docker_password
     when:
       event: push
       branch: develop
 
   publish_latest:
-    image: plugins/docker
-    repo: nytimes/drone-gke
-    tag:
-      - "latest"
-      - "0.8"
-    secrets:
-      - docker_username
-      - docker_password
-    when:
-      event: push
-      branch: master
+    <<: *publish_config
+    auto_tag: true
 
-  publish_release:
-    image: plugins/docker
-    repo: nytimes/drone-gke
-    tag:
-      - "${DRONE_TAG}"
-    secrets:
-      - docker_username
-      - docker_password
-    when:
-      event: tag
+  publish_1_8:
+    <<: *publish_config
+    auto_tag: true
+    auto_tag_suffix: "1.8"
+    dockerfile: Dockerfile.1.8
+
+  publish_1_9:
+    <<: *publish_config
+    auto_tag: true
+    auto_tag_suffix: "1.9"
+    dockerfile: Dockerfile.1.9
 
   slack:
     image: plugins/slack

--- a/Dockerfile.1.8
+++ b/Dockerfile.1.8
@@ -1,5 +1,5 @@
-# latest kubectl in the SDK
-FROM google/cloud-sdk:alpine
+# kubectl 1.8.6
+FROM google/cloud-sdk:184.0.0-alpine
 
 # Install kubectl
 RUN gcloud components install kubectl && \
@@ -11,3 +11,4 @@ ENV CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
 ADD drone-gke /bin/
 
 ENTRYPOINT ["/bin/drone-gke"]
+

--- a/Dockerfile.1.9
+++ b/Dockerfile.1.9
@@ -1,5 +1,5 @@
-# latest kubectl in the SDK
-FROM google/cloud-sdk:alpine
+# kubectl 1.9.7
+FROM google/cloud-sdk:206.0.0-alpine
 
 # Install kubectl
 RUN gcloud components install kubectl && \

--- a/README.md
+++ b/README.md
@@ -6,21 +6,26 @@ For the usage information and a listing of the available options please take a l
 This is a little simpler than deploying straight to Kubernetes, because the API endpoints and credentials can be derived using the Google credentials.
 In addition, this opens the yaml file to templatization and customization with each Drone build.
 
-## Drone Compatibility
+## Drone compatibility
 
-For usage in Drone 0.5 and newer, please use a [release tag](https://hub.docker.com/r/nytimes/drone-gke/tags/) greater than `0.7`.
+For usage in Drone 0.5 and newer, please use a [release tag](https://hub.docker.com/r/nytimes/drone-gke/tags/) >= `0.7`.
 
-For usage in Drone 0.4, please use the `nytimes/drone-gke:0.4` tag.
+For usage in Drone 0.4, please use a `0.4` [release tag](https://hub.docker.com/r/nytimes/drone-gke/tags/).
 
 ## Releases
 
 Users should use the `x.X` releases for stable use cases (eg 0.8).
 
-Breaking changes may occur between `x.X` releases (eg 0.7 and 0.8), and will be documented in the changelog.
+Breaking changes may occur between `x.X` releases (eg 0.7 and 0.8), and will be documented in the release notes.
 
 - Pushes to the [`develop`](https://github.com/NYTimes/drone-gke/tree/develop) branch will update the Docker Hub release tagged `develop`.
-- Pushes to the [`master`](https://github.com/NYTimes/drone-gke/tree/master) branch will update the Docker Hub release tagged `latest` and `x.X` (eg 0.7).
-- Tags to the [`master`](https://github.com/NYTimes/drone-gke/tree/master) branch will create the Docker Hub release with the tag value (eg 0.7.1).
+- Pushes to the [`master`](https://github.com/NYTimes/drone-gke/tree/master) branch will update the Docker Hub release tagged `latest`.
+- Tags to the [`master`](https://github.com/NYTimes/drone-gke/tree/master) branch will create the Docker Hub release with the tag value (eg `0.7.1` and `0.7`).
+
+## kubectl version
+
+Use the [release tag](https://hub.docker.com/r/nytimes/drone-gke/tags/) suffix with the desired `kubectl` version.
+The last three minor releases are supported ([same as GKE](https://cloud.google.com/kubernetes-engine/versioning-and-upgrades)).
 
 ## Development
 


### PR DESCRIPTION
Since GKE supports the latest 3 `kubectl` versions, this update will publish each version of the plugin with images for each `kubectl` version.

When a new version is released, we just need to add a Dockerfile and remove the deprecated one.