### PR TITLE
fix kubeconfig context name generation for regional use (0.8.x)

### DIFF
--- a/main.go
+++ b/main.go
@@ -526,7 +526,19 @@ func setNamespace(c *cli.Context, project string, runner Runner) error {
 	// Set the execution namespace.
 	log("Configuring kubectl to the %s namespace\n", namespace)
 
-	context := strings.Join([]string{"gke", project, c.String("zone"), c.String("cluster")}, "_")
+	// set cluster location segment based on parameters provided to plugin
+	// checkParams requires at least one of zone or region to be provided and prevents use of both at the same time
+	clusterLocation := ""
+	if c.String("zone") != "" {
+		clusterLocation = c.String("zone")
+	}
+
+	if c.String("region") != "" {
+		clusterLocation = c.String("region")
+	}
+
+	context := strings.Join([]string{"gke", project, clusterLocation, c.String("cluster")}, "_")
+
 	if err := runner.Run(kubectlCmd, "config", "set-context", context, "--namespace", namespace); err != nil {
 		return fmt.Errorf("Error: %s\n", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -344,8 +344,8 @@ func TestPrintKubectlVersion(t *testing.T) {
 }
 
 func TestSetNamespace(t *testing.T) {
-	// No error
-	set := flag.NewFlagSet("test-set", 0)
+	// Zonal args set
+	set := flag.NewFlagSet("zonal-set", 0)
 	set.String("zone", "us-east1-b", "")
 	set.String("cluster", "cluster-0", "")
 	set.String("namespace", "test-ns", "")
@@ -356,6 +356,21 @@ func TestSetNamespace(t *testing.T) {
 	testRunner.On("Run", []string{"kubectl", "config", "set-context", "gke_test-project_us-east1-b_cluster-0", "--namespace", "test-ns"}).Return(nil)
 	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--filename", "/tmp/namespace.json"}).Return(nil)
 	err := setNamespace(c, "test-project", testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+
+	// Region args set
+	set = flag.NewFlagSet("regional-set", 0)
+	set.String("region", "us-west1", "")
+	set.String("cluster", "regional-cluster", "")
+	set.String("namespace", "test-ns", "")
+	set.Bool("dry-run", false, "")
+	c = cli.NewContext(nil, set, nil)
+
+	testRunner = new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "config", "set-context", "gke_test-project_us-west1_regional-cluster", "--namespace", "test-ns"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--record", "--filename", "/tmp/namespace.json"}).Return(nil)
+	err = setNamespace(c, "test-project", testRunner)
 	testRunner.AssertExpectations(t)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
the recent changes to support regional clusters did not include updates to the kubeconfig context name generation logic.. some sample results of the current issue when used with the `regional` parameter:

```sh
kubectl config set-context gke_my-project__my-cluster --namespace qa
# Context "gke_my-project__my-cluster" created.
```

the namespace resource is successfully created, and if you explicitly configure the namespace of resources within your templates, those resources will be configured properly, but for users that do not explicitly configure the namespace within their templates (relying on the context instead), their resources will end up applied, but to the default namespace.