### PR TITLE
fix kubeconfig context name generation for regional use (0.4.x)

### DIFF
--- a/main.go
+++ b/main.go
@@ -302,7 +302,18 @@ func wrapMain() error {
 	if len(vargs.Namespace) > 0 {
 		fmt.Printf("Configuring kubectl to the %s namespace\n", vargs.Namespace)
 
-		context := strings.Join([]string{"gke", vargs.Project, vargs.Zone, vargs.Cluster}, "_")
+		// set cluster location segment based on parameters provided to plugin
+		// earlier validation logic requires at least one of zone or region to be provided and prevents use of both at the same time
+		clusterLocation := ""
+		if vargs.Zone != "" {
+			clusterLocation = vargs.Zone
+		}
+
+		if vargs.Region != "" {
+			clusterLocation = vargs.Region
+		}
+
+		context := strings.Join([]string{"gke", vargs.Project, clusterLocation, vargs.Cluster}, "_")
 
 		err = runner.Run(vargs.KubectlCmd, "config", "set-context", context, "--namespace", vargs.Namespace)
 		if err != nil {


### PR DESCRIPTION
the recent changes to support regional clusters did not include updates to the kubeconfig context name generation logic.. some sample results of the current issue when used with the `regional` parameter:

```sh
kubectl config set-context gke_my-project__my-cluster --namespace qa
# Context "gke_my-project__my-cluster" created.
```

the namespace resource is successfully created, and if you explicitly configure the namespace of resources within your templates, those resources will be configured properly, but for users that do not explicitly configure the namespace within their templates (relying on the context instead), their resources will end up applied, but to the default namespace.