### PR TITLE
Clarify k8s version in tag name

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,13 +53,13 @@ pipeline:
   publish_1_8:
     <<: *publish_config
     auto_tag: true
-    auto_tag_suffix: "1.8"
+    auto_tag_suffix: "k8s-1.8"
     dockerfile: Dockerfile.1.8
 
   publish_1_9:
     <<: *publish_config
     auto_tag: true
-    auto_tag_suffix: "1.9"
+    auto_tag_suffix: "k8s-1.9"
     dockerfile: Dockerfile.1.9
 
   slack:


### PR DESCRIPTION
Having only 2 numbers as the tag name is confusing (eg `0.8.3-1.8` or `0.8-1.8` or `1.8`).
Better to make it clear second number is the k8s version (eg `0.8.3-k8s-1.8` or `0.8-k8s-1.8` or `k8s-1.8`).