### PR TITLE
Just build from the latest version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,9 +45,7 @@ pipeline:
 
   publish_develop:
     <<: *publish_config
-    build_args:
-    - GCLOUD_SDK_TAG=alpine
-    tag:
+    tags:
       - "develop"
     when:
       event: push
@@ -55,8 +53,6 @@ pipeline:
 
   publish_release:
     <<: *publish_config
-    build_args:
-    - GCLOUD_SDK_TAG=alpine
     auto_tag: true
 
   slack:

--- a/.drone.yml
+++ b/.drone.yml
@@ -53,31 +53,16 @@ pipeline:
       event: push
       branch: develop
 
-  publish_latest:
+  publish_release:
     <<: *publish_config
     build_args:
     - GCLOUD_SDK_TAG=alpine
     auto_tag: true
 
-  publish_1_10:
-    <<: *publish_config
-    build_args:
-    - GCLOUD_SDK_TAG=217.0.0-alpine
-    auto_tag: true
-    auto_tag_suffix: "k8s-1.10"
-
-  publish_1_11:
-    <<: *publish_config
-    build_args:
-    - GCLOUD_SDK_TAG=241.0.0-alpine
-    auto_tag: true
-    auto_tag_suffix: "k8s-1.11"
-
   slack:
     image: plugins/slack
     channel: dv-notifications
-    secrets:
-      - slack_webhook
+    secrets: [slack_webhook]
     when:
       branch:
         - develop
@@ -86,8 +71,7 @@ pipeline:
   slack_tag:
     image: plugins/slack
     channel: dv-notifications
-    secrets:
-      - slack_webhook
+    secrets: [slack_webhook]
     when:
       event:
         - tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-# see https://hub.docker.com/r/google/cloud-sdk/tags for available tags / versions
-ARG GCLOUD_SDK_TAG
-
-FROM google/cloud-sdk:${GCLOUD_SDK_TAG}
+FROM google/cloud-sdk:alpine
 
 ENV CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
 ENV CLOUDSDK_CORE_DISABLE_PROMPTS=1

--- a/README.md
+++ b/README.md
@@ -17,19 +17,27 @@ Derive the API endpoints and credentials from the Google credentials and open th
 
 ### Tool
 
+This tool follows [semantic versioning](https://semver.org/).
+
 Use the `x.X` releases for stable use cases (eg 0.8).
 Breaking changes may occur between `x.X` releases (eg 0.7 and 0.8), and will be documented in the [release notes](https://github.com/nytimes/drone-gke/releases).
 
 ### Kubernetes API
 
-Use the release [tag](https://hub.docker.com/r/nytimes/drone-gke/tags/) suffixed with your desired `kubectl` version.
-The last two-three minor releases are supported ([same as GKE](https://cloud.google.com/kubernetes-engine/versioning-and-upgrades)).
+Since the [237.0.0 (2019-03-05) Google Cloud SDK][sdk], the container image contains multiple versions of `kubectl`.
+The corresponding client version that matches the cluster version will be used automatically.
+This follows the minor release support that ([GKE offers](https://cloud.google.com/kubernetes-engine/versioning-and-upgrades)).
+
+If you want to use a different version, you can specify the version of `kubectl` used with the [`kubectl_version` parameter][version-parameter].
+
+[sdk]: https://cloud.google.com/sdk/docs/release-notes#23700_2019-03-05
+[version-parameter]: DOCS.md#kubectl_version
 
 ### Container
 
 - Pushes to the [`develop`](https://github.com/nytimes/drone-gke/tree/develop) branch will update the image tagged `develop`.
-- Pushes to the [`master`](https://github.com/nytimes/drone-gke/tree/master) branch will update the images tagged `latest` and corresponding `kubectl` versions.
-- Tags to the [`master`](https://github.com/nytimes/drone-gke/tree/master) branch will create the images with the tag value (eg `0.7.1` and `0.7`) and corresponding `kubectl` versions.
+- Pushes to the [`master`](https://github.com/nytimes/drone-gke/tree/master) branch will update the image tagged `latest`.
+- Tags to the [`master`](https://github.com/nytimes/drone-gke/tree/master) branch will create the images with the patch and minor tag values (eg `0.7.1` and `0.7`).
 
 ## Usage
 


### PR DESCRIPTION
No need to specify which version of the SDK since the original intent was to support multiple `kubectl` versions at the same time (see https://github.com/nytimes/drone-gke/pull/90).