### PR TITLE
Issue 99: Generalize 'wait-deployments' to handle other rollouts like StatefulSets

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -166,13 +166,37 @@ pipeline:
     # ...
 ```
 
+### `wait_rollouts`
+
+_**type**_ `[]string`
+
+_**default**_ `[]`
+
+_**description**_ wait for the listed rollouts using `kubectl rollout status ...`
+
+_**example**_
+
+```yaml
+# .drone.yml
+---
+pipeline:
+  # ...
+  deploy:
+    image: nytimes/drone-gke
+    wait_rollouts:
+    - deployment/nginx
+    - deployment/memcache
+    - statefulset/hazelcast
+    # ...
+```
+
 ### `wait_deployments`
 
 _**type**_ `[]string`
 
 _**default**_ `[]`
 
-_**description**_ list of Deployments to wait for successful rollout, using `kubectl rollout status`
+_**description**_ list of Deployments to wait for successful rollout, using `kubectl rollout status`.  (see also `wait-rollouts`)
 
 _**example**_
 

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ run :
 		--env PLUGIN_TEMPLATE \
 		--env PLUGIN_VARS \
 		--env PLUGIN_VERBOSE \
+		--env PLUGIN_WAIT_ROLLOUTS \
 		--env PLUGIN_WAIT_DEPLOYMENTS \
 		--env PLUGIN_WAIT_SECONDS \
 		--env PLUGIN_ZONE \


### PR DESCRIPTION
I've added a new option "wait-rollouts" and left "wait-deployments" for backwards compatibility.  I did, however, make significant changes to the `waitForRollouts` function so it could handle both cases rather than duplicating much of the existing function.  I was careful to add test cases for both.

Please take a look and let me know if I am missing anything or if you have any questions or concerns!

Thanks!  Bennett
