### PR TITLE
Issue 99: Generalize 'wait-deployments' to handle other rollouts like StatefulSets

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -172,9 +172,10 @@ _**type**_ `[]string`
 
 _**default**_ `[]`
 
-_**description**_ wait for the given deployments using `kubectl rollout status ...`.  Deployments
-can be specified as `"<type>/<name>"` as expected by `kubectl`.  If just `"<name>"` is given it 
-will be defaulted to `"deployment/<name>"`.  
+_**description**_ wait for the given deployments using `kubectl rollout status ...`
+
+_**notes**_ deployments can be specified as `"<type>/<name>"` as expected by `kubectl`.  If 
+just `"<name>"` is given it will be defaulted to `"deployment/<name>"`.  
 
 _**example**_
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -172,7 +172,9 @@ _**type**_ `[]string`
 
 _**default**_ `[]`
 
-_**description**_ list of Deployments to wait for successful rollout, using `kubectl rollout status`
+_**description**_ wait for the given deployments using `kubectl rollout status ...`.  Deployments
+can be specified as `"<type>/<name>"` as expected by `kubectl`.  If just `"<name>"` is given it 
+will be defaulted to `"deployment/<name>"`.  
 
 _**example**_
 
@@ -184,9 +186,9 @@ pipeline:
   deploy:
     image: nytimes/drone-gke
     wait_deployments:
-    - app
+    - deployment/app
+    - statefulset/memcache
     - nginx
-    - memcache
     # ...
 ```
 

--- a/main_test.go
+++ b/main_test.go
@@ -481,19 +481,38 @@ func TestApplyManifests(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestWaitForRollout(t *testing.T) {
-	// No error
+// RunWaitForRollout is a helper function for testing WaitForRollout.  For each flag-value
+// in flagValues it will expect a corresponding call of the form:
+// "kubectl rollout status <expected-value> ..."
+func RunWaitForRollout(t *testing.T, specs []string, expectedValues []string) {
 	set := flag.NewFlagSet("test-set", 0)
 	set.Int("wait-seconds", 256, "")
 	set.String("namespace", "test-ns", "")
+	strSlice := cli.StringSlice{}
+	for _, spec := range specs {
+		strSlice.Set(spec)
+	}
+	strSliceFlag := cli.StringSliceFlag{Name: "wait-deployments", Value: &strSlice}
+	strSliceFlag.Apply(set)
 	c := cli.NewContext(nil, set, nil)
-
 	testRunner := new(MockedRunner)
-	testRunner.On("Run", []string{"timeout", "-t", "256", "kubectl", "rollout", "status", "deployment", "d1", "--namespace", "test-ns"}).Return(nil)
-	testRunner.On("Run", []string{"timeout", "-t", "256", "kubectl", "rollout", "status", "deployment", "d2", "--namespace", "test-ns"}).Return(nil)
-	err := waitForRollout(c, testRunner, []string{"d1", "d2"})
+	for _, s := range expectedValues {
+		testRunner.On("Run", []string{"timeout", "-t", "256", "kubectl", "rollout", "status", s, "--namespace", "test-ns"}).Return(nil)
+	}
+	err := waitForRollout(c, testRunner)
 	testRunner.AssertExpectations(t)
 	assert.NoError(t, err)
+}
+
+func TestWaitForRollout(t *testing.T) {
+	RunWaitForRollout(t, []string{"deployment/d1"}, []string{"deployment/d1"})
+	RunWaitForRollout(t,
+		[]string{"deployment/d1", "statefulset/s1"},
+		[]string{"deployment/d1", "statefulset/s1"})
+	RunWaitForRollout(t, []string{"d1"}, []string{"deployment/d1"})
+	RunWaitForRollout(t,
+		[]string{"d1", "d2"},
+		[]string{"deployment/d1", "deployment/d2"})
 }
 
 func TestApplyArgs(t *testing.T) {


### PR DESCRIPTION
After some discussion in [PR 124](https://github.com/nytimes/drone-gke/pull/124) this PR takes a different approach.  Instead of adding a new option and deprecating the existing option this PR just generalizes the existing option to handle an additional format of input that can specify the type.