### PR TITLE
Fix skipping templates for Drone 1.x

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -219,6 +219,44 @@ pipeline:
     # ...
 ```
 
+### `skip_template`
+
+_**type**_ `bool`
+
+_**default**_ `false`
+
+_**description**_ parse and apply the Kubernetes manifest template
+
+_**notes**_ turn off the use of the template, regardless if the file exists or not
+
+_**example**_
+
+```yaml
+# .drone.yml
+
+# Drone 1.0+
+---
+kind: pipeline
+# ...
+steps:
+  - name: deploy-gke
+    image: nytimes/drone-gke
+    settings:
+      template: k8s/app.yaml
+      skip_template: true
+      # ...
+
+# Drone 0.8
+---
+pipeline:
+  # ...
+  deploy:
+    image: nytimes/drone-gke
+    template: k8s/app.yaml
+    skip_template: true
+    # ...
+```
+
 ### `secret_template`
 
 _**type**_ `string`
@@ -252,6 +290,44 @@ pipeline:
   deploy:
     image: nytimes/drone-gke
     secret_template: my-templates/secrets.yaml
+    # ...
+```
+
+### `skip_secret_template`
+
+_**type**_ `bool`
+
+_**default**_ `false`
+
+_**description**_ parse and apply the Kubernetes _Secret_ resource manifest template
+
+_**notes**_ turn off the use of the template, regardless if the file exists or not
+
+_**example**_
+
+```yaml
+# .drone.yml
+
+# Drone 1.0+
+---
+kind: pipeline
+# ...
+steps:
+  - name: deploy-gke
+    image: nytimes/drone-gke
+    settings:
+      secret_template: my-templates/secrets.yaml
+      skip_secret_template: true
+      # ...
+
+# Drone 0.8
+---
+pipeline:
+  # ...
+  deploy:
+    image: nytimes/drone-gke
+    secret_template: my-templates/secrets.yaml
+    skip_secret_template: true
     # ...
 ```
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -191,7 +191,8 @@ _**default**_ `'.kube.yml'`
 
 _**description**_ path to Kubernetes manifest template
 
-_**notes**_ rendered using the Go [`text/template`](https://golang.org/pkg/text/template/) package
+_**notes**_ rendered using the Go [`text/template`](https://golang.org/pkg/text/template/) package.
+If the file does not exist, set `skip_template` to `true`.
 
 _**example**_
 
@@ -265,7 +266,8 @@ _**default**_ `'.kube.sec.yml'`
 
 _**description**_ path to Kubernetes [_Secret_ resource](http://kubernetes.io/docs/user-guide/secrets/) manifest template
 
-_**notes**_ rendered using the Go [`text/template`](https://golang.org/pkg/text/template/) package
+_**notes**_ rendered using the Go [`text/template`](https://golang.org/pkg/text/template/) package.
+If the file does not exist, set `skip_secret_template` to `true`.
 
 _**example**_
 

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func getAppFlags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:    "skip-template",
-			Usage:   "do not parse or apply the kube template",
+			Usage:   "do not parse or apply the Kubernetes template",
 			EnvVars: []string{"PLUGIN_SKIP_TEMPLATE"},
 		},
 		&cli.StringFlag{
@@ -121,7 +121,7 @@ func getAppFlags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:    "skip-secret-template",
-			Usage:   "do not parse or apply the secret template",
+			Usage:   "do not parse or apply the Kubernetes Secret template",
 			EnvVars: []string{"PLUGIN_SKIP_SECRET_TEMPLATE"},
 		},
 		&cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -512,6 +512,7 @@ func renderTemplates(c *cli.Context, templateData map[string]interface{}, secret
 	// YAML files path for kubectl
 	for t, content := range mapping {
 		if t == "" {
+			log("Warning: skipping template %s because it was set to be ignored\n", t)
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -563,7 +563,7 @@ func renderTemplates(c *cli.Context, templateData map[string]interface{}, secret
 				return nil, fmt.Errorf("Error finding template: %s\n", err)
 			}
 
-			log("Warning: skipping optional template %s because it was not found\n", t)
+			log("Warning: skipping optional secret template %s because it was not found\n", t)
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func getAppFlags() []cli.Flag {
 			Value:   ".kube.yml",
 		},
 		&cli.BoolFlag{
-			Name:    "skip-kube-template",
+			Name:    "skip-template",
 			Usage:   "do not parse or apply the kube template",
 			EnvVars: []string{"PLUGIN_SKIP_TEMPLATE"},
 		},
@@ -372,7 +372,7 @@ func getProjectFromToken(j string) string {
 // As of Drone 1.7, env vars that have an empty string as the value are dropped.
 // So we need to use and check the new set of flags to determine if the user wants to skip processing a template file.
 func parseSkips(c *cli.Context) error {
-	if c.Bool("skip-kube-template") {
+	if c.Bool("skip-template") {
 		log("Warning: skipping kube-template because it was set to be ignored\n")
 		if err := c.Set("kube-template", ""); err != nil {
 			return err
@@ -385,7 +385,7 @@ func parseSkips(c *cli.Context) error {
 		}
 	}
 
-	if c.Bool("skip-kube-template") && c.Bool("skip-secret-template") {
+	if c.Bool("skip-template") && c.Bool("skip-secret-template") {
 		return fmt.Errorf("Error: skipping both templates ends the plugin execution")
 	}
 

--- a/main.go
+++ b/main.go
@@ -386,7 +386,7 @@ func parseSkips(c *cli.Context) error {
 	}
 
 	if c.Bool("skip-template") && c.Bool("skip-secret-template") {
-		return fmt.Errorf("Error: skipping both templates ends the plugin execution")
+		return fmt.Errorf("Error: skipping both templates ends the plugin execution\n")
 	}
 
 	return nil
@@ -553,7 +553,6 @@ func renderTemplates(c *cli.Context, templateData map[string]interface{}, secret
 	// YAML files path for kubectl
 	for t, content := range mapping {
 		if t == "" {
-			log("Warning: skipping template %s because it was set to be ignored\n", t)
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -104,15 +104,25 @@ func getAppFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:    "kube-template",
-			Usage:   "optional - template for Kubernetes resources, e.g. deployments",
+			Usage:   "template for Kubernetes resources, e.g. deployments",
 			EnvVars: []string{"PLUGIN_TEMPLATE"},
 			Value:   ".kube.yml",
 		},
+		&cli.BoolFlag{
+			Name:    "skip-kube-template",
+			Usage:   "do not parse or apply the kube template",
+			EnvVars: []string{"PLUGIN_SKIP_TEMPLATE"},
+		},
 		&cli.StringFlag{
 			Name:    "secret-template",
-			Usage:   "optional - template for Kubernetes Secret resources",
+			Usage:   "template for Kubernetes Secret resources",
 			EnvVars: []string{"PLUGIN_SECRET_TEMPLATE"},
 			Value:   ".kube.sec.yml",
+		},
+		&cli.BoolFlag{
+			Name:    "skip-secret-template",
+			Usage:   "do not parse or apply the secret template",
+			EnvVars: []string{"PLUGIN_SKIP_SECRET_TEMPLATE"},
 		},
 		&cli.StringFlag{
 			Name:    "vars",

--- a/main_test.go
+++ b/main_test.go
@@ -607,8 +607,8 @@ func TestTokenParamPrecedence(t *testing.T) {
 			name:           "both-and-plugin-token-wins",
 			envToken:       "token456",
 			envPluginToken: "token123",
-			expectedOk:    true,
-			expectedToken: "token123",
+			expectedOk:     true,
+			expectedToken:  "token123",
 		},
 		{
 			name:           "missing-token",
@@ -621,7 +621,7 @@ func TestTokenParamPrecedence(t *testing.T) {
 	} {
 		t.Run(tst.name, func(t *testing.T) {
 			os.Clearenv()
-			
+
 			os.Setenv("PLUGIN_REGION", "region-123")
 			os.Setenv("PLUGIN_CLUSTER", "cluster-123")
 

--- a/main_test.go
+++ b/main_test.go
@@ -386,7 +386,7 @@ func TestParseSkips(t *testing.T) {
 	kubeSet := flag.NewFlagSet("kube-set", 0)
 	kubeSet.String("kube-template", kubeTemplatePath, "")
 	kubeSet.String("secret-template", secretTemplatePath, "")
-	kubeSet.Bool("skip-kube-template", true, "")
+	kubeSet.Bool("skip-template", true, "")
 	c = cli.NewContext(nil, kubeSet, nil)
 	err = parseSkips(c)
 	assert.NoError(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -368,6 +368,43 @@ func TestRenderTemplates(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParseSkips(t *testing.T) {
+	kubeTemplatePath := "/tmp/drone-gke-tests/.kube.yml"
+	secretTemplatePath := "/tmp/drone-gke-tests/.kube.sec.yml"
+
+	// Test no skip
+	set := flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", kubeTemplatePath, "")
+	set.String("secret-template", secretTemplatePath, "")
+	c := cli.NewContext(nil, set, nil)
+	err := parseSkips(c)
+	assert.NoError(t, err)
+	assert.Equal(t, kubeTemplatePath, c.String("kube-template"))
+	assert.Equal(t, secretTemplatePath, c.String("secret-template"))
+
+	// Test skip template
+	kubeSet := flag.NewFlagSet("kube-set", 0)
+	kubeSet.String("kube-template", kubeTemplatePath, "")
+	kubeSet.String("secret-template", secretTemplatePath, "")
+	kubeSet.Bool("skip-kube-template", true, "")
+	c = cli.NewContext(nil, kubeSet, nil)
+	err = parseSkips(c)
+	assert.NoError(t, err)
+	assert.Empty(t, c.String("kube-template"))
+	assert.Equal(t, secretTemplatePath, c.String("secret-template"))
+
+	// Test skip template
+	secretSet := flag.NewFlagSet("secret-set", 0)
+	secretSet.String("kube-template", kubeTemplatePath, "")
+	secretSet.String("secret-template", secretTemplatePath, "")
+	secretSet.Bool("skip-secret-template", true, "")
+	c = cli.NewContext(nil, secretSet, nil)
+	err = parseSkips(c)
+	assert.NoError(t, err)
+	assert.Equal(t, kubeTemplatePath, c.String("kube-template"))
+	assert.Empty(t, c.String("secret-template"))
+}
+
 func TestPrintKubectlVersion(t *testing.T) {
 	testRunner := new(MockedRunner)
 	testRunner.On("Run", []string{"kubectl", "version"}).Return(nil)

--- a/main_test.go
+++ b/main_test.go
@@ -382,6 +382,13 @@ func TestParseSkips(t *testing.T) {
 	assert.Equal(t, kubeTemplatePath, c.String("kube-template"))
 	assert.Equal(t, secretTemplatePath, c.String("secret-template"))
 
+	// Test skipping both
+	set.Bool("skip-template", true, "")
+	set.Bool("skip-secret-template", true, "")
+	c = cli.NewContext(nil, set, nil)
+	err = parseSkips(c)
+	assert.Error(t, err)
+
 	// Test skip template
 	kubeSet := flag.NewFlagSet("kube-set", 0)
 	kubeSet.String("kube-template", kubeTemplatePath, "")


### PR DESCRIPTION
Drone 1.x (tested in 1.7) drops environment variables whose value is an empty string `""`, eg `PLUGIN_VAR=""` is removed from the environment.

In order to remove dependency on how Drone exposes environment variables, this stops using the `""` sentinel value to determine skipping processing a `template` or `secret_template` file.

Instead explicit configuration is required to skip processing those files if they exist in the working directory:

- `skip_template: bool`
- `skip_secret_template: bool`