### PR TITLE
Typo

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,9 +27,6 @@ slack_config: &slack_config
     SLACK_WEBHOOK:
       from_secret: slack_webhook
 
-  channel: dv-notifications
-  secrets: [slack_webhook]
-
 steps:
 - <<: *go_config
   name: test


### PR DESCRIPTION
Realized this typo when making https://github.com/nytimes/drone-eks/pull/14
