### PR TITLE
Update any references to master to use main instead

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,7 +40,7 @@ steps:
   - go build -a -ldflags "-X main.version=n/a -X main.rev=${DRONE_COMMIT}"
   when:
     branch:
-    - master
+    - main
 
 - <<: *go_config
   name: build_release
@@ -67,7 +67,7 @@ steps:
   name: slack
   when:
     branch:
-    - master
+    - main
 
 - <<: *slack_config
   name: slack_tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Before submitting changes, please follow these guidelines:
 
 The git workflow follows [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html).
 
-New features should be based on the `master` branch.
+New features should be based on the `main` branch.
 
 ### Dependencies
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -560,7 +560,7 @@ These variables are always available to reference in any manifest, and cannot be
 
 ```json
 {
-  "BRANCH": "master",
+  "BRANCH": "main",
   "BUILD_NUMBER": "12",
   "COMMIT": "4923x0c3380413ec9288e3c0bfbf534b0f18fed1",
   "TAG": "",
@@ -669,7 +669,7 @@ steps:
     secrets: [google_credentials]
     when:
       event: push
-      branch: master
+      branch: main
 
   - name: gke
     image: nytimes/drone-gke
@@ -693,7 +693,7 @@ steps:
         user: $${USER}
     when:
       event: push
-      branch: master
+      branch: main
 ```
 
 ### `.kube.yml`

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docker_default_repo_name = nytimes
 docker_image_name = drone-gke
 docker_default_tag = latest
 ifneq ($(git_current_branch), $(git_default_branch))
-	# if current branch name is NOT .git/refs/remotes/origin/HEAD (i.e., master)
+	# if current branch name is NOT .git/refs/remotes/origin/HEAD (i.e., main)
 	# then use the current branch name as the default docker tag
 	docker_default_tag = $(git_current_branch)
 endif

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This tool follows [semantic versioning](https://semver.org/).
 Use the minor version (`x.X`) releases for stable use cases (eg 0.9).
 Changes are documented in the [release notes](https://github.com/nytimes/drone-gke/releases).
 
-- Pushes to the [`master`](https://github.com/nytimes/drone-gke/tree/master) branch will update the image tagged `latest`.
+- Pushes to the [`main`](https://github.com/nytimes/drone-gke/tree/main) branch will update the image tagged `latest`.
 - Releases will create the images with each major/minor/patch tag values (eg `0.7.1` and `0.7`).
 
 ### Kubernetes API

--- a/main_test.go
+++ b/main_test.go
@@ -210,7 +210,7 @@ func TestFetchCredentials(t *testing.T) {
 func TestTemplateData(t *testing.T) {
 	// Set cli.Context with data
 	set := flag.NewFlagSet("test-set", 0)
-	set.String("drone-branch", "master", "")
+	set.String("drone-branch", "main", "")
 	set.String("drone-build-number", "2", "")
 	set.String("drone-commit", "e0f21b90a", "")
 	set.String("drone-tag", "v0.0.0", "")
@@ -228,7 +228,7 @@ func TestTemplateData(t *testing.T) {
 
 	// Verify
 	assert.Equal(t, map[string]interface{}{
-		"BRANCH":       "master",
+		"BRANCH":       "main",
 		"BUILD_NUMBER": "2",
 		"COMMIT":       "e0f21b90a",
 		"TAG":          "v0.0.0",
@@ -241,7 +241,7 @@ func TestTemplateData(t *testing.T) {
 	}, tmplData)
 
 	assert.Equal(t, map[string]interface{}{
-		"BRANCH":       "master",
+		"BRANCH":       "main",
 		"BUILD_NUMBER": "2",
 		"COMMIT":       "e0f21b90a",
 		"TAG":          "v0.0.0",
@@ -274,7 +274,7 @@ func TestTemplateDataExpandingVars(t *testing.T) {
 
 	// Set cli.Context with data
 	set := flag.NewFlagSet("test-set", 0)
-	set.String("drone-branch", "master", "")
+	set.String("drone-branch", "main", "")
 	set.String("drone-build-number", "2", "")
 	set.String("drone-commit", "e0f21b90a", "")
 	set.String("drone-tag", "v0.0.0", "")
@@ -293,7 +293,7 @@ func TestTemplateDataExpandingVars(t *testing.T) {
 
 	// Verify
 	assert.Equal(t, map[string]interface{}{
-		"BRANCH":       "master",
+		"BRANCH":       "main",
 		"BUILD_NUMBER": "2",
 		"COMMIT":       "e0f21b90a",
 		"TAG":          "v0.0.0",
@@ -306,7 +306,7 @@ func TestTemplateDataExpandingVars(t *testing.T) {
 	}, tmplData)
 
 	assert.Equal(t, map[string]interface{}{
-		"BRANCH":       "master",
+		"BRANCH":       "main",
 		"BUILD_NUMBER": "2",
 		"COMMIT":       "e0f21b90a",
 		"TAG":          "v0.0.0",
@@ -681,9 +681,9 @@ func TestTokenParamPrecedence(t *testing.T) {
 
 func TestSetDryRunFlag(t *testing.T) {
 	tests := []struct {
-		name string
+		name                 string
 		versionCommandOutput string
-		explicitVersion string
+		explicitVersion      string
 
 		expectedFlag string
 	}{
@@ -703,7 +703,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "",
-			expectedFlag: dryRunFlagPre118,
+			expectedFlag:    dryRunFlagPre118,
 		},
 		{
 			name: "kubectl-1.15",
@@ -721,7 +721,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.15",
-			expectedFlag: dryRunFlagPre118,
+			expectedFlag:    dryRunFlagPre118,
 		},
 		{
 			name: "kubectl-1.16",
@@ -739,7 +739,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.16",
-			expectedFlag: dryRunFlagPre118,
+			expectedFlag:    dryRunFlagPre118,
 		},
 		{
 			name: "kubectl-1.17",
@@ -757,7 +757,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.17",
-			expectedFlag: dryRunFlagPre118,
+			expectedFlag:    dryRunFlagPre118,
 		},
 		{
 			name: "kubectl-1.18",
@@ -775,7 +775,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.18",
-			expectedFlag: dryRunFlagDefault,
+			expectedFlag:    dryRunFlagDefault,
 		},
 		{
 			name: "kubectl-1.19",
@@ -793,7 +793,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.19",
-			expectedFlag: dryRunFlagDefault,
+			expectedFlag:    dryRunFlagDefault,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Will update settings to make default branch `main` before merging. Will make sure to keep branch protection for `master` in addition to `main` branch

`drone-eks` PR: https://github.com/nytimes/drone-eks/pull/17 (merged)

<!--
Hi there,

Thank you for opening a pull request, we will get back to you as soon as possible!
-->

If this is a change to the core functionality, did you make a corresponding PR to [drone-eks]?
- [x] yes
- [ ] no
- [ ] n/a

Did you update the tests?
- [x] yes
- [ ] no
- [ ] n/a

Did you update the docs?
- [x] yes
- [ ] no
- [ ] n/a

[drone-eks]: https://github.com/NYTimes/drone-eks
