### PR TITLE
Enable service account keys to be provided in base64

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -515,7 +515,7 @@ steps:
 
 `drone-gke` requires a Google service account and uses its [JSON credential file][service-account] to authenticate.
 
-This must be passed to the plugin under the target `token`.
+This must be passed to the plugin under the target `token`. If provided in base64 format, the plugin will decode it internally.
 
 The plugin infers the GCP project from the JSON credentials (`token`) and retrieves the GKE cluster credentials.
 


### PR DESCRIPTION
We'd like to have Drone secrets in base64 be passed directly to the token param.

The main use case is to integrate directly with the [Vault Google Cloud Secrets Engine](https://www.vaultproject.io/docs/secrets/gcp#service-account-keys) that returns the service account key in base64.

Example:

```yaml
---
kind: secret
name: google_credentials_b64
get:
  path: gcp/roleset/gke-deploy/key
  name: private_key_data
---
kind: pipeline
name: default
steps:
[...]
name: gke-deploy
  image: nytimes/drone-gke
  environment:
    TOKEN:
      from_secret: google_credentials_b64
  settings:
    namespace: my-ns
    region: us-east1
    cluster: my-cluster
  when:
    event: push
    branch: main
```

In this particular example, the path `gcp/roleset/gke-deploy/key` is associated with Vault roleset as described [here](https://www.vaultproject.io/docs/secrets/gcp#service-account-keys).

<!--
Hi there,

Thank you for opening a pull request, we will get back to you as soon as possible!
-->

If this is a change to the core functionality, did you make a corresponding PR to [drone-eks]?
- [ ] yes
- [ ] no
- [x] n/a

Did you update the tests?
- [x] yes
- [ ] no
- [ ] n/a

Did you update the docs?
- [x] yes
- [ ] no
- [ ] n/a

[drone-eks]: https://github.com/NYTimes/drone-eks
