### PR TITLE
Skip Docker Login on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
         
     - name: Login to Docker Hub
       uses: docker/login-action@v2
+      if: ${{ github.event_name != 'pull_request' }}
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
This change should allow Dependabot to open PRs since it will not need access to secrets