### PR TITLE
Add support for performing server-side applies

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -565,6 +565,29 @@ steps:
       # ...
 ```
 
+### `server_side`
+
+_**type**_ `bool`
+
+_**default**_ `false`
+
+_**description**_ Perform a Kubernetes [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
+
+_**example**_
+
+```yaml
+# .drone.yml
+---
+kind: pipeline
+# ...
+steps:
+  - name: deploy-gke
+    image: nytimes/drone-gke
+    settings:
+      server_side: true
+      # ...
+```
+
 ### `verbose`
 
 _**type**_ `bool`

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ run :
 	@$(docker) run \
 		--env PLUGIN_CLUSTER \
 		--env PLUGIN_DRY_RUN \
+		--env PLUGIN_SERVER_SIDE \
 		--env PLUGIN_EXPAND_ENV_VARS \
 		--env PLUGIN_KUBECTL_VERSION \
 		--env PLUGIN_NAMESPACE \

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ const (
 
 	clientSideDryRunFlagPre118  = "--dry-run=true"
 	clientSideDryRunFlagDefault = "--dry-run=client"
+	serverSideDryRunFlagPre118  = "--server-dry-run=true"
+	serverSideDryRunFlagDefault = "--dry-run=server"
 	serverSideFlag              = "--server-side"
 )
 

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ const (
 	clientSideDryRunFlagDefault = "--dry-run=client"
 	serverSideDryRunFlagPre118  = "--server-dry-run=true"
 	serverSideDryRunFlagDefault = "--dry-run=server"
-	serverSideFlag              = "--server-side"
+	serverSideApplyFlag         = "--server-side"
 )
 
 // default to kubectlCmdName, can be overriden via kubectl-version param
@@ -450,13 +450,15 @@ func parseSkips(c *cli.Context) error {
 // used and whether the apply should be client-side or server-side
 func setDryRunFlag(runner Runner, output io.Reader, c *cli.Context) error {
 	dryRunFlag = clientSideDryRunFlagDefault
-	isServerSideApply := c.Bool("server-side")
 
 	version, err := getMinorVersion(runner, output)
 	if err != nil {
 		return fmt.Errorf("Error determining which kubectl version is running: %v", err)
 	}
 
+	isServerSideApply := c.Bool("server-side")
+
+	// Default is the >= 1.18 flag for both server- and client-side dry runs
 	if isServerSideApply {
 		if version < 18 {
 			dryRunFlag = serverSideDryRunFlagPre118
@@ -917,7 +919,7 @@ func applyArgs(dryrun bool, serverSide bool, file string) []string {
 	}
 
 	if serverSide {
-		args = append(args, serverSideFlag)
+		args = append(args, serverSideApplyFlag)
 	}
 
 	args = append(args, "--filename")

--- a/main.go
+++ b/main.go
@@ -456,19 +456,17 @@ func setDryRunFlag(runner Runner, output io.Reader, c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("Error determining which kubectl version is running: %v", err)
 	}
-	// default is the >= 1.18 flag
-	if version < 18 {
-		if isServerSideApply {
-			dryRunFlag = serverSideDryRunFlagPre118
-		} else {
-			dryRunFlag = clientSideDryRunFlagPre118
-		}
-
-		return nil
-	}
 
 	if isServerSideApply {
-		dryRunFlag = serverSideDryRunFlagDefault
+		if version < 18 {
+			dryRunFlag = serverSideDryRunFlagPre118
+		} else {
+			dryRunFlag = serverSideDryRunFlagDefault
+		}
+	} else {
+		if version < 18 {
+			dryRunFlag = clientSideDryRunFlagPre118
+		}
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -39,9 +39,9 @@ const (
 	nsPath           = "/tmp/namespace.json"
 	templateBasePath = "/tmp"
 
-	dryRunFlagPre118  = "--dry-run=true"
-	dryRunFlagDefault = "--dry-run=client"
-	serverSideFlag    = "--server-side"
+	clientSideDryRunFlagPre118  = "--dry-run=true"
+	clientSideDryRunFlagDefault = "--dry-run=client"
+	serverSideFlag              = "--server-side"
 )
 
 // default to kubectlCmdName, can be overriden via kubectl-version param
@@ -55,7 +55,7 @@ metadata:
   name: %s
 `
 var invalidNameRegex = regexp.MustCompile(`[^a-z0-9\.\-]+`)
-var dryRunFlag = dryRunFlagDefault
+var dryRunFlag = clientSideDryRunFlagDefault
 
 func main() {
 	err := wrapMain()
@@ -447,14 +447,14 @@ func parseSkips(c *cli.Context) error {
 // setDryRunFlag sets the value of the dry-run flag for the version of kubectl
 // that is being used
 func setDryRunFlag(runner Runner, output io.Reader) error {
-	dryRunFlag = dryRunFlagDefault
+	dryRunFlag = clientSideDryRunFlagDefault
 	version, err := getMinorVersion(runner, output)
 	if err != nil {
 		return fmt.Errorf("Error determining which kubectl version is running: %v", err)
 	}
 	// default is the >= 1.18 flag
 	if version < 18 {
-		dryRunFlag = dryRunFlagPre118
+		dryRunFlag = clientSideDryRunFlagPre118
 	}
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -632,11 +632,14 @@ func TestWaitForJobs(t *testing.T) {
 }
 
 func TestApplyArgs(t *testing.T) {
-	args := applyArgs(false, "/path/to/file/1")
+	args := applyArgs(false, false, "/path/to/file/1")
 	assert.Equal(t, []string{"apply", "--filename", "/path/to/file/1"}, args)
 
-	args = applyArgs(true, "/path/to/file/2")
+	args = applyArgs(true, false, "/path/to/file/2")
 	assert.Equal(t, []string{"apply", "--dry-run=client", "--filename", "/path/to/file/2"}, args)
+
+	args = applyArgs(false, true, "/path/to/file/3")
+	assert.Equal(t, []string{"apply", "--server-side", "--filename", "/path/to/file/3"}, args)
 }
 
 func TestPrintTrimmedError(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -758,7 +758,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "",
-			expectedFlag:    dryRunFlagPre118,
+			expectedFlag:    clientSideDryRunFlagPre118,
 		},
 		{
 			name: "kubectl-1.15",
@@ -776,7 +776,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.15",
-			expectedFlag:    dryRunFlagPre118,
+			expectedFlag:    clientSideDryRunFlagPre118,
 		},
 		{
 			name: "kubectl-1.16",
@@ -794,7 +794,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.16",
-			expectedFlag:    dryRunFlagPre118,
+			expectedFlag:    clientSideDryRunFlagPre118,
 		},
 		{
 			name: "kubectl-1.17",
@@ -812,7 +812,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.17",
-			expectedFlag:    dryRunFlagPre118,
+			expectedFlag:    clientSideDryRunFlagPre118,
 		},
 		{
 			name: "kubectl-1.18",
@@ -830,7 +830,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.18",
-			expectedFlag:    dryRunFlagDefault,
+			expectedFlag:    clientSideDryRunFlagDefault,
 		},
 		{
 			name: "kubectl-1.19",
@@ -848,7 +848,7 @@ func TestSetDryRunFlag(t *testing.T) {
 				}
 			}`,
 			explicitVersion: "1.19",
-			expectedFlag:    dryRunFlagDefault,
+			expectedFlag:    clientSideDryRunFlagDefault,
 		},
 	}
 	for _, test := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -739,6 +740,7 @@ func TestSetDryRunFlag(t *testing.T) {
 		name                 string
 		versionCommandOutput string
 		explicitVersion      string
+		isServerSide         bool
 
 		expectedFlag string
 	}{
@@ -815,6 +817,25 @@ func TestSetDryRunFlag(t *testing.T) {
 			expectedFlag:    clientSideDryRunFlagPre118,
 		},
 		{
+			name: "kubectl-1.17",
+			versionCommandOutput: `{
+				"clientVersion": {
+					"major": "1",
+					"minor": "17",
+					"gitVersion": "v1.17.17",
+					"gitCommit": "f3abc15296f3a3f54e4ee42e830c61047b13895f",
+					"gitTreeState": "clean",
+					"buildDate": "2021-01-13T13:21:12Z",
+					"goVersion": "go1.13.15",
+					"compiler": "gc",
+					"platform": "linux/amd64"
+				}
+			}`,
+			explicitVersion: "1.17",
+			isServerSide:    true,
+			expectedFlag:    serverSideDryRunFlagPre118,
+		},
+		{
 			name: "kubectl-1.18",
 			versionCommandOutput: `{
 				"clientVersion": {
@@ -831,6 +852,25 @@ func TestSetDryRunFlag(t *testing.T) {
 			}`,
 			explicitVersion: "1.18",
 			expectedFlag:    clientSideDryRunFlagDefault,
+		},
+		{
+			name: "kubectl-1.18",
+			versionCommandOutput: `{
+				"clientVersion": {
+					"major": "1",
+					"minor": "18",
+					"gitVersion": "v1.18.15",
+					"gitCommit": "73dd5c840662bb066a146d0871216333181f4b64",
+					"gitTreeState": "clean",
+					"buildDate": "2021-01-13T13:22:41Z",
+					"goVersion": "go1.13.15",
+					"compiler": "gc",
+					"platform": "linux/amd64"
+				}
+			}`,
+			explicitVersion: "1.18",
+			isServerSide:    true,
+			expectedFlag:    serverSideDryRunFlagDefault,
 		},
 		{
 			name: "kubectl-1.19",
@@ -856,6 +896,7 @@ func TestSetDryRunFlag(t *testing.T) {
 			os.Clearenv()
 
 			os.Setenv("PLUGIN_KUBECTL_VERSION", test.explicitVersion)
+			os.Setenv("PLUGIN_SERVER_SIDE", strconv.FormatBool(test.isServerSide))
 
 			err := (&cli.App{
 				Flags: getAppFlags(),

--- a/main_test.go
+++ b/main_test.go
@@ -918,7 +918,7 @@ func TestSetDryRunFlag(t *testing.T) {
 					}
 
 					// Run
-					setDryRunFlag(testRunner, buf)
+					setDryRunFlag(testRunner, buf, ctx)
 
 					// Check
 					if dryRunFlag != test.expectedFlag {


### PR DESCRIPTION
Closes #190 with a new flag to perform [server-side applies](https://kubernetes.io/docs/reference/using-api/server-side-apply/).

If this is a change to the core functionality, did you make a corresponding PR to [drone-eks]?
- [x] yes
- [ ] no
- [ ] n/a

Did you update the tests?
- [x] yes
- [ ] no
- [ ] n/a

Did you update the docs?
- [x] yes
- [ ] no
- [ ] n/a

[drone-eks]: https://github.com/NYTimes/drone-eks
