### PR TITLE
Sanitize namespace flag consistently

### DIFF
--- a/main.go
+++ b/main.go
@@ -381,11 +381,20 @@ func checkParams(c *cli.Context) error {
 		return fmt.Errorf("Missing required param: cluster")
 	}
 
+	namespace := c.String("namespace")
+	c.Set("namespace", sanitizeNamespace(namespace))
+
 	if err := validateKubectlVersion(c, extraKubectlVersions); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func sanitizeNamespace(namespace string) string {
+	namespace = strings.ToLower(namespace)
+	namespace = invalidNameRegex.ReplaceAllString(namespace, "-")
+	return namespace
 }
 
 // validateKubectlVersion tests whether a given version is valid within the current environment
@@ -728,10 +737,6 @@ func setNamespace(c *cli.Context, project string, runner Runner) error {
 	if namespace == "" {
 		return nil
 	}
-
-	//replace invalid char in namespace
-	namespace = strings.ToLower(namespace)
-	namespace = invalidNameRegex.ReplaceAllString(namespace, "-")
 
 	// Set the execution namespace.
 	log("Configuring kubectl to the %s namespace\n", namespace)

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -208,7 +207,8 @@ func TestFetchCredentials(t *testing.T) {
 	assert.NoError(t, regionalErr)
 
 	// Verify token file
-	buf, err := ioutil.ReadFile("/tmp/gcloud.json")
+	buf, err := os.ReadFile("/tmp/gcloud.json")
+	assert.NoError(t, err)
 	assert.Equal(t, "{\"key\", \"val\"}", string(buf))
 
 	// Run() error
@@ -270,13 +270,13 @@ func TestTemplateData(t *testing.T) {
 
 	// Variable overrides existing ones
 	vars = map[string]interface{}{"zone": "us-east4-b"}
-	tmplData, secretsData, secretsDataRedacted, err = templateData(c, "us-east1-b", vars, secrets)
+	_, _, _, err = templateData(c, "us-east1-b", vars, secrets)
 	assert.Error(t, err)
 
 	// Secret overrides variable
 	vars = map[string]interface{}{"SECRET_TEST": "val0"}
 	secrets = map[string]string{"SECRET_TEST": "test_val"}
-	tmplData, secretsData, secretsDataRedacted, err = templateData(c, "us-east1-b", vars, secrets)
+	_, _, _, err = templateData(c, "us-east1-b", vars, secrets)
 	assert.Error(t, err)
 }
 
@@ -335,19 +335,20 @@ func TestTemplateDataExpandingVars(t *testing.T) {
 
 	// Variable overrides existing ones
 	vars = map[string]interface{}{"zone": "us-east4-b"}
-	tmplData, secretsData, secretsDataRedacted, err = templateData(c, "us-east1-b", vars, secrets)
+	_, _, _, err = templateData(c, "us-east1-b", vars, secrets)
 	assert.Error(t, err)
 
 	// Secret overrides variable
 	vars = map[string]interface{}{"SECRET_TEST": "val0"}
 	secrets = map[string]string{"SECRET_TEST": "test_val"}
-	tmplData, secretsData, secretsDataRedacted, err = templateData(c, "us-east1-b", vars, secrets)
+	_, _, _, err = templateData(c, "us-east1-b", vars, secrets)
 	assert.Error(t, err)
 }
 
 func TestRenderTemplates(t *testing.T) {
 	// Mkdir for testing template files
-	os.MkdirAll("/tmp/drone-gke-tests/", os.ModePerm)
+	err := os.MkdirAll("/tmp/drone-gke-tests/", os.ModePerm)
+	assert.NoError(t, err)
 	kubeTemplatePath := "/tmp/drone-gke-tests/.kube.yml"
 	secretTemplatePath := "/tmp/drone-gke-tests/.kube.sec.yml"
 
@@ -370,16 +371,16 @@ func TestRenderTemplates(t *testing.T) {
 	// No template file, should error
 	os.Remove(kubeTemplatePath)
 	os.Remove(secretTemplatePath)
-	_, err := renderTemplates(c, tmplData, secretsData)
+	_, err = renderTemplates(c, tmplData, secretsData)
 	assert.Error(t, err)
 
 	// Normal
 	// Create test template files
 	tmplBuf := []byte("{{.COMMIT}}-{{.key0}}")
-	err = ioutil.WriteFile(kubeTemplatePath, tmplBuf, 0600)
+	err = os.WriteFile(kubeTemplatePath, tmplBuf, 0600)
 	assert.NoError(t, err)
 	tmplBuf = []byte("{{.COMMIT}}-{{.SECRET_TEST}}")
-	err = ioutil.WriteFile(secretTemplatePath, tmplBuf, 0600)
+	err = os.WriteFile(secretTemplatePath, tmplBuf, 0600)
 	assert.NoError(t, err)
 
 	// Render
@@ -387,15 +388,18 @@ func TestRenderTemplates(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify token files
-	buf, err := ioutil.ReadFile(manifestPaths[kubeTemplatePath])
+	buf, err := os.ReadFile(manifestPaths[kubeTemplatePath])
+	assert.NoError(t, err)
 	assert.Equal(t, "e0f21b90a-val0", string(buf))
 
-	buf, err = ioutil.ReadFile(manifestPaths[secretTemplatePath])
+	buf, err = os.ReadFile(manifestPaths[secretTemplatePath])
+	assert.NoError(t, err)
 	assert.Equal(t, "e0f21b90a-test_sec_val", string(buf))
 
 	// Secret variables shouldn't be available in kube template
 	tmplBuf = []byte("{{.SECRET_TEST}}")
-	err = ioutil.WriteFile(kubeTemplatePath, tmplBuf, 0600)
+	err = os.WriteFile(kubeTemplatePath, tmplBuf, 0600)
+	assert.NoError(t, err)
 	_, err = renderTemplates(c, tmplData, secretsData)
 	assert.Error(t, err)
 }
@@ -486,7 +490,8 @@ func TestSetNamespace(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify written file
-	buf, err := ioutil.ReadFile("/tmp/namespace.json")
+	buf, err := os.ReadFile("/tmp/namespace.json")
+	assert.NoError(t, err)
 	assert.Equal(t, "\n---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: test-ns\n", string(buf))
 
 	// Dry-run
@@ -902,6 +907,7 @@ func TestSetDryRunFlag(t *testing.T) {
 			expectedFlag:    clientSideDryRunFlagDefault,
 		},
 	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			os.Clearenv()
@@ -929,7 +935,8 @@ func TestSetDryRunFlag(t *testing.T) {
 					}
 
 					// Run
-					setDryRunFlag(testRunner, buf, ctx)
+					err := setDryRunFlag(testRunner, buf, ctx)
+					assert.NoError(t, err)
 
 					// Check
 					if dryRunFlag != test.expectedFlag {
@@ -938,7 +945,6 @@ func TestSetDryRunFlag(t *testing.T) {
 					return nil
 				},
 			}).Run([]string{"run"})
-
 			if err != nil {
 				t.Fatalf("unepected err: %v", err)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -493,7 +493,7 @@ func TestSetNamespace(t *testing.T) {
 	set = flag.NewFlagSet("test-set", 0)
 	set.String("zone", "us-east1-b", "")
 	set.String("cluster", "cluster-0", "")
-	set.String("namespace", "feature-1892-test-ns", "")
+	set.String("namespace", "feature-1892-test-ns", "") // the namespace is already sanitized by this point
 	set.Bool("dry-run", true, "")
 	set.Bool("create-namespace", true, "")
 	c = cli.NewContext(nil, set, nil)
@@ -509,7 +509,7 @@ func TestSetNamespace(t *testing.T) {
 	set = flag.NewFlagSet("no-create-namespace-set", 0)
 	set.String("zone", "us-east1-b", "")
 	set.String("cluster", "cluster-0", "")
-	set.String("namespace", "feature-1892-test-ns", "")
+	set.String("namespace", "feature-1892-test-ns", "") // the namespace is already sanitized by this point
 	set.Bool("dry-run", false, "")
 	set.Bool("create-namespace", false, "")
 	c = cli.NewContext(nil, set, nil)


### PR DESCRIPTION
## Problem

This plugin accepts a `namespace` var and creates a K8s namespace using that value. K8s namespaces must contain only lowercase alphanumeric characters and dashes, and begin with an alphanumeric character ([reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/)).

To handle the possibility that users will provide values for `namespace` that are invalid as K8s namespace names, the plugin [sanitizes](https://github.com/nytimes/drone-eks/blob/de151fc870261f47157af0a06bd70a952704b0b2/main.go#L708-L709) the value before creating the namespace. This ensures that namespace creation does not fail due to an invalid name.

However, when the plugin calls `kubectl rollout`, it [passes the unsanitized, user-provided namespace value](https://github.com/nytimes/drone-eks/blob/main/main.go#L781). As a result, if the `namespace` var required sanitization to be a valid K8s namespace name, the rollout command will specify a namespace that does not exist, and will fail with the message:

```
namespaces "$NAMESPACE_VAR" not found
```

## Fix

I see two options here:
1. Reject `namespace` values that are not valid K8s namespaces.
2. Sanitize the user-inputted value for use in the rollout command.

I've implemented (2) in `checkParams`.

I prefer approach  because it allows the most flexibility for users. For instance, a common usage pattern is to pass the git branch name as the drone-gke namespace value. Branch names can have capital letters and other characters not allowed in K8s branch names. Option (2) allows users to continue the practice of using branch names without having to restrict the characters they can use in their git branches.

## PR Form

If this is a change to the core functionality, did you make a corresponding PR to [drone-eks]?

https://github.com/nytimes/drone-eks/pull/75

- [x] yes
- [ ] no
- [ ] n/a

Did you update the tests?
- [x] yes
- [ ] no
- [ ] n/a

Did you update the docs?
> I'm thinking of this as a bug fix, so I didn't think an update to the docs was warranted. Let me know if there's a change I should make.

- [ ] yes
- [x] no
- [ ] n/a

[drone-eks]: https://github.com/NYTimes/drone-eks
