### PR TITLE
Fix skip_template & skip_secret_template options. Reorder manifest apply

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -187,7 +187,8 @@ _**default**_ `'.kube.yml'`
 _**description**_ path to Kubernetes manifest template
 
 _**notes**_ rendered using the Go [`text/template`](https://golang.org/pkg/text/template/) package.
-If the file does not exist, set `skip_template` to `true`.
+The `secret_template` manifest (`.kube.sec.yml`) will apply prior to the `template` manifest (`.kube.yml`), as the secrets may need to be available to the main manifest file.
+If the file does not exist or you do not want the plugin to apply the template, set `skip_template` to `true`.
 
 _**example**_
 
@@ -239,7 +240,8 @@ _**default**_ `'.kube.sec.yml'`
 _**description**_ path to Kubernetes [_Secret_ resource](http://kubernetes.io/docs/user-guide/secrets/) manifest template
 
 _**notes**_ rendered using the Go [`text/template`](https://golang.org/pkg/text/template/) package.
-If the file does not exist, set `skip_secret_template` to `true`.
+The `secret_template` manifest (`.kube.sec.yml`) will apply prior to the `template` manifest (`.kube.yml`), as the secrets may need to be available to the main manifest file.
+If the file does not exist or you do not want the plugin to apply the template, set `skip_secret_template` to `true`.
 
 _**example**_
 

--- a/main_test.go
+++ b/main_test.go
@@ -535,27 +535,27 @@ func TestApplyManifests(t *testing.T) {
 	c := cli.NewContext(nil, set, nil)
 
 	manifestPaths := map[string]string{
-		".kube.yml":     "/path/to/kube-tamplate",
-		".kube.sec.yml": "/path/to/secret-tamplate",
+		".kube.yml":     "/path/to/kube-template",
+		".kube.sec.yml": "/path/to/secret-template",
 	}
 
 	testRunner := new(MockedRunner)
-	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-tamplate"}).Return(nil)
-	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-tamplate"}).Return(nil)
-	testRunner.On("Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-tamplate"}).Return(nil)
-	testRunner.On("Run", []string{"kubectl", "apply", "--filename", "/path/to/secret-tamplate"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-template"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--filename", "/path/to/secret-template"}).Return(nil)
 	err := applyManifests(c, manifestPaths, testRunner, testRunner)
 	testRunner.AssertExpectations(t)
 	assert.NoError(t, err)
 
 	// No secrets manifest
 	manifestPaths = map[string]string{
-		".kube.yml": "/path/to/kube-tamplate",
+		".kube.yml": "/path/to/kube-template",
 	}
 
 	testRunner = new(MockedRunner)
-	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-tamplate"}).Return(nil)
-	testRunner.On("Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-tamplate"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-template"}).Return(nil)
 	err = applyManifests(c, manifestPaths, testRunner, testRunner)
 	testRunner.AssertExpectations(t)
 	assert.NoError(t, err)
@@ -568,16 +568,156 @@ func TestApplyManifests(t *testing.T) {
 	c = cli.NewContext(nil, set, nil)
 
 	manifestPaths = map[string]string{
-		".kube.yml":     "/path/to/kube-tamplate",
-		".kube.sec.yml": "/path/to/secret-tamplate",
+		".kube.yml":     "/path/to/kube-template",
+		".kube.sec.yml": "/path/to/secret-template",
 	}
 
 	testRunner = new(MockedRunner)
-	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-tamplate"}).Return(nil)
-	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-tamplate"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"}).Return(nil)
 	err = applyManifests(c, manifestPaths, testRunner, testRunner)
 	testRunner.AssertExpectations(t)
 	assert.NoError(t, err)
+
+	// skip_secret_template: true
+	set = flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", ".kube.yml", "")
+	set.String("secret-template", ".kube.sec.yml", "")
+	set.Bool("skip-secret-template", true, "")
+	set.Bool("dry-run", false, "")
+	c = cli.NewContext(nil, set, nil)
+
+	manifestPaths = map[string]string{
+		".kube.yml":     "/path/to/kube-template",
+		".kube.sec.yml": "/path/to/secret-template",
+	}
+
+	testRunner = new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-template"}).Return(nil)
+	err = applyManifests(c, manifestPaths, testRunner, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+	testRunner.AssertCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"})
+	testRunner.AssertCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/secret-template"})
+
+	// skip_template: true
+	set = flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", ".kube.yml", "")
+	set.String("secret-template", ".kube.sec.yml", "")
+	set.Bool("skip-template", true, "")
+	set.Bool("dry-run", false, "")
+	c = cli.NewContext(nil, set, nil)
+
+	manifestPaths = map[string]string{
+		".kube.yml":     "/path/to/kube-template",
+		".kube.sec.yml": "/path/to/secret-template",
+	}
+
+	testRunner = new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"}).Return(nil)
+	testRunner.On("Run", []string{"kubectl", "apply", "--filename", "/path/to/secret-template"}).Return(nil)
+	err = applyManifests(c, manifestPaths, testRunner, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+	testRunner.AssertCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"})
+	testRunner.AssertCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/secret-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-template"})
+
+	// skip_template: true, skip_secret_template: true
+	set = flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", ".kube.yml", "")
+	set.String("secret-template", ".kube.sec.yml", "")
+	set.Bool("skip-template", true, "")
+	set.Bool("skip-secret-template", true, "")
+	set.Bool("dry-run", false, "")
+	c = cli.NewContext(nil, set, nil)
+
+	manifestPaths = map[string]string{
+		".kube.yml":     "/path/to/kube-template",
+		".kube.sec.yml": "/path/to/secret-template",
+	}
+
+	testRunner = new(MockedRunner)
+	err = applyManifests(c, manifestPaths, testRunner, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/secret-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-template"})
+
+	// skip_secret_template: true, dry-run: true
+	set = flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", ".kube.yml", "")
+	set.String("secret-template", ".kube.sec.yml", "")
+	set.Bool("skip-secret-template", true, "")
+	set.Bool("dry-run", true, "")
+	c = cli.NewContext(nil, set, nil)
+
+	manifestPaths = map[string]string{
+		".kube.yml":     "/path/to/kube-template",
+		".kube.sec.yml": "/path/to/secret-template",
+	}
+
+	testRunner = new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"}).Return(nil)
+	err = applyManifests(c, manifestPaths, testRunner, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/secret-template"})
+	testRunner.AssertCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-template"})
+
+	// skip_template: true, dry-run: true
+	set = flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", ".kube.yml", "")
+	set.String("secret-template", ".kube.sec.yml", "")
+	set.Bool("skip-template", true, "")
+	set.Bool("dry-run", true, "")
+	c = cli.NewContext(nil, set, nil)
+
+	manifestPaths = map[string]string{
+		".kube.yml":     "/path/to/kube-template",
+		".kube.sec.yml": "/path/to/secret-template",
+	}
+
+	testRunner = new(MockedRunner)
+	testRunner.On("Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"}).Return(nil)
+	err = applyManifests(c, manifestPaths, testRunner, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+	testRunner.AssertCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/secret-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-template"})
+
+	// skip_template: true, skip_secret_template: true, dry-run: true
+	set = flag.NewFlagSet("test-set", 0)
+	set.String("kube-template", ".kube.yml", "")
+	set.String("secret-template", ".kube.sec.yml", "")
+	set.Bool("skip-template", true, "")
+	set.Bool("skip-secret-template", true, "")
+	set.Bool("dry-run", true, "")
+	c = cli.NewContext(nil, set, nil)
+
+	manifestPaths = map[string]string{
+		".kube.yml":     "/path/to/kube-template",
+		".kube.sec.yml": "/path/to/secret-template",
+	}
+
+	testRunner = new(MockedRunner)
+	err = applyManifests(c, manifestPaths, testRunner, testRunner)
+	testRunner.AssertExpectations(t)
+	assert.NoError(t, err)
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/secret-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/secret-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--dry-run=client", "--filename", "/path/to/kube-template"})
+	testRunner.AssertNotCalled(t, "Run", []string{"kubectl", "apply", "--filename", "/path/to/kube-template"})
 }
 
 // RunWaitForRollout is a helper function for testing WaitForRollout.  For each flag-value


### PR DESCRIPTION
This PR is to make the `skip_template` and `skip_secret_template` options functional. They currently do not work and still attempt to run when they are set to true.

The application order of the two manifest files was also changes so that the `secret_template` manifest is applied prior to the `template` manifest since the resources in the `template` manifest may need to use the secrets added by the `secret_template`.

Changes:
- Add check for when `skip_template` is set to `true` in the `applyManifests` function to skip the k8s manifest set in `template`. This will also skip dry runs
- Add check in `applyManifests` function to check if the `template` variable is empty prior to applying changes
- Add check for when `skip_secret_template` is set to `true` in the `applyManifests` function to skip the k8s manifest set in `secret_template`. This will also skip dry runs
- Add check in `applyManifests` function to check if the `secret_template` variable is empty prior to applying changes
- Reverse the order of k8s manifest applications so that the `secret_template` manifest is applied before the `template` manifest. This is a dependency issue where some of the k8s resources from the `template` manifest will need to have access to the secrets from the `secret_template` manifest
- Add test for `skip_template: true`
- Add test for `skip_secret_template: true`
- Add test for `skip_template: true, skip_secret_template: true`
- Add test for `skip_template: true, dry_run: true`
- Add test for `skip_secret_template: true, dry_run: true`
- Add test for `skip_template: true, skip_secret_template: true, dry_run: true`
- Update `DOCS.md` to be more explicit about above changes

If this is a change to the core functionality, did you make a corresponding PR to [drone-eks]?
- [x] yes
- [ ] no
- [ ] n/a

Did you update the tests?
- [x] yes
- [ ] no
- [ ] n/a

Did you update the docs?
- [x] yes
- [ ] no
- [ ] n/a

[drone-eks]: https://github.com/NYTimes/drone-eks
